### PR TITLE
Add support for running API tests without a running server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ jobs:
         - diff build/api.md docs/api.md
 
         # Test local development
+        - npm run test:api
         - APP_SERVER_PORT=9001 npm --prefix server run start &
         - APP_SERVER_PORT=9001 bash misc/test-server.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
         - diff build/api.md docs/api.md
 
         # Test local development
-        - npm run test:api
+        - npm --prefix server run test:api
         - APP_SERVER_PORT=9001 npm --prefix server run start &
         - APP_SERVER_PORT=9001 bash misc/test-server.sh
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -66,12 +66,13 @@ NPM scripts for development for server:
 | --- | --- |
 | `start` | Start the server in development mode with default configuration. Hosts the API and static content at `localhost:8080` |
 | `watch` | Like `start`, but also builds the **client** automatically when the code changes. |
+| `test:api` | Run API tests. |
 
 Rarely manually needed NPM scripts for server:
 
 | Command | Description |
 | --- | --- |
-| `test:api` | Run automated API tests, requires having the server running at `localhost:8080`. |
+| `test:remoteapi` | Run automated API tests for an already running server at port 8080 or env `APP_SERVER_PORT`. |
 
 ## Docker
 

--- a/misc/test-server.sh
+++ b/misc/test-server.sh
@@ -5,7 +5,7 @@ set -e
 set -u
 
 # Test server endpoints
-npm --prefix server run test:api
+npm --prefix server run test:remoteapi
 
 # Download main bundle file and print size
 mkdir -p build

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1060,6 +1060,16 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cross-env": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
+      "integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.5",
+        "is-windows": "^1.0.0"
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -2080,6 +2090,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
     },
     "isarray": {
       "version": "1.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,8 @@
     "lint": "eslint .",
     "lint:ci": "eslint . --rule \"{ \\\"linebreak-style\\\": [2, \\\"unix\\\"] }\"",
     "start": "babel-node src/setup.js",
-    "test:api": "mocha --require @babel/register --timeout 20000 src/api-tests",
+    "test:remoteapi": "mocha --require @babel/register --timeout 20000 src/api-tests",
+    "test:api": "cross-env APP_SERVER_PORT=8086 babel-node src/setup.js --testApi",
     "doc": "light-api-doc -t ../misc/api-template.md -o ../docs/api.md src",
     "watch": "babel-node src/setup.js --watch"
   },
@@ -16,6 +17,7 @@
   "license": "MIT",
   "devDependencies": {
     "@babel/register": "^7.0.0",
+    "cross-env": "^5.2.0",
     "eslint": "^5.3.0",
     "eslint-config-airbnb": "^17.1.0",
     "eslint-plugin-import": "^2.14.0",

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -31,7 +31,7 @@ export function startServer() {
   if (args.testApi) {
     // Start a server to a random OS chosen port and run tests
     const server = app.listen(0, () => {
-      const port = server.address().port
+      const { port } = server.address()
 
       const npmExecutable = /^win/.test(process.platform) ? 'npm.cmd' : 'npm'
       const proc = childProcess.spawn(npmExecutable, ['run', 'test:remoteapi'], {
@@ -50,7 +50,7 @@ export function startServer() {
   } else {
     // Actual server start
     const port = checkInt('port', config.port)
-    const server = app.listen(port, () => {
+    app.listen(port, () => {
       console.log(`Running on port ${port}`)
     })
   }

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -28,11 +28,11 @@ export function startServer() {
     return
   }
 
-  const port = checkInt('port', config.port)
-  const server = app.listen(port, () => {
-    console.log(`Running on port ${port}`)
+  if (args.testApi) {
+    // Start a server to a random OS chosen port and run tests
+    const server = app.listen(0, () => {
+      const port = server.address().port
 
-    if (args.testApi) {
       const npmExecutable = /^win/.test(process.platform) ? 'npm.cmd' : 'npm'
       const proc = childProcess.spawn(npmExecutable, ['run', 'test:remoteapi'], {
         stdio: 'inherit',
@@ -46,7 +46,13 @@ export function startServer() {
         process.exitCode = code
         server.close()
       })
-    }
-  })
+    })
+  } else {
+    // Actual server start
+    const port = checkInt('port', config.port)
+    const server = app.listen(port, () => {
+      console.log(`Running on port ${port}`)
+    })
+  }
 }
 

--- a/server/src/setup.js
+++ b/server/src/setup.js
@@ -32,6 +32,13 @@ function parseArguments() {
     }
   )
 
+  parser.addArgument(
+    ['--testApi'], {
+      help: 'Run API tests an exit',
+      action: 'storeTrue',
+    }
+  )
+
   const argsToSet = parser.parseArgs()
   Object.assign(args, argsToSet)
 }


### PR DESCRIPTION
Renamed `test:api` to `test:remoteapi` which requires a running server. `test:api` now starts a server on port 8086 and runs tests.