### PR TITLE
Don't let unrelated window messages interrupt persistence

### DIFF
--- a/client/src/persist.js
+++ b/client/src/persist.js
@@ -121,9 +121,6 @@ export function setupPersist(loadPersist) {
   })
 
   window.addEventListener('message', (event) => {
-    if (allDataLoaded) return
-    allDataLoaded = true
-
     if (event.source !== persistWindow) return
     const msg = event.data
     if (typeof msg !== 'object') return
@@ -136,10 +133,12 @@ export function setupPersist(loadPersist) {
     saveLocalState(json)
     saveGlobalState(json)
 
+    if (allDataLoaded) return
+    allDataLoaded = true
+
     loadPersist(state, true)
     window.clearTimeout(timeout)
   })
 
   return savePersist
 }
-


### PR DESCRIPTION
Before this unrelated messages (from example React Devtools)
would cause `allDataLoaded` to be true, but no actual data
would be loaded because the function would return in the
following checks. Then the loadPersist callback would never be
called and a user created.