### PR TITLE
Thread support

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -34,7 +34,8 @@
     "no-prototype-builtins": "off",
     "class-methods-use-this": "off",
     "no-continue": "off",
-    "object-curly-newline": "off"
+    "object-curly-newline": "off",
+    "method-can-be-static": "off"
   },
 
   "globals": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1696,7 +1696,7 @@
     },
     "callsites": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
@@ -2244,7 +2244,7 @@
         },
         "regjsparser": {
           "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+          "resolved": "http://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
           "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
           "dev": true,
           "requires": {
@@ -3295,8 +3295,7 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3320,15 +3319,13 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3345,22 +3342,19 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3491,8 +3485,7 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3506,7 +3499,6 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3523,7 +3515,6 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3532,15 +3523,13 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": false,
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3561,7 +3550,6 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3650,8 +3638,7 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3665,7 +3652,6 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3761,8 +3747,7 @@
           "version": "5.1.1",
           "resolved": false,
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3804,7 +3789,6 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3826,7 +3810,6 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3875,15 +3858,13 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": false,
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -7284,7 +7265,7 @@
     },
     "stream-browserify": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "dev": true,
       "requires": {
@@ -7350,7 +7331,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {

--- a/client/src/components/add-username-modal/add-username-modal.js
+++ b/client/src/components/add-username-modal/add-username-modal.js
@@ -63,7 +63,14 @@ class UsernameModal extends React.Component {
         shouldCloseOnOverlayClick
         shouldCloseOnEsc
       >
-        <form className={css('modal-content')} onSubmit={this.handleSubmit}>
+        <h4 className={css('header')}>Add Username</h4>
+        <div className={css('body')}>
+          <div className={css('text')}>
+              Add a username to be associated with your account on Feedbacker Forum.
+              Your name will be visible above all of your comments.
+          </div>
+        </div>
+        <form className={css('modal-form')} onSubmit={this.handleSubmit}>
           <input type="text" onChange={this.handleChange} name="name" id="name" placeholder="New username..." />
           <input className={css('add-button')} type="submit" value="Add username" />
         </form>

--- a/client/src/components/add-username-modal/add-username-modal.scss
+++ b/client/src/components/add-username-modal/add-username-modal.scss
@@ -11,11 +11,11 @@
   flex-flow: column;
   justify-content: space-around;
   position: fixed;
-  right: $baseline;
-  bottom: $baseline;
-  min-width: 35vw;
-  min-height: 15vh;
-  max-height: 40vh;
+  min-width: 20 * $baseline;
+  max-width: 400px;
+  min-height: 2 * $baseline;
+  max-height: 300px;
+  padding: $spacer;
   border: solid $palette-light 1px;
   border-radius: $border-radius-default;
   background-color: $palette-lighter;
@@ -25,31 +25,34 @@
     outline: none;
     box-shadow: 0 2px 10px $palette-shadow-default;
   }
-}
-
-input[type="submit"] {
-  @include button();
-  align-self: flex-end;
-  margin-top: $baseline;
-  padding: $baseline $spacer;
-  background: $palette-accent;
-  color: $palette-lighter;
-}
-
-.modal-content {
-  align-items: center;
-  display: flex;
-  flex-flow: column;
-  flex: 1;
-  justify-content: center;
-  padding: 1em 2em;
-  input[type="text"] {
-    @extend .comment;
-    display: block;
-    min-width: 100%;
-    border: none;
+  .header {
+    text-align: center;
+  }
+  .modal-form {
+    align-items: center;
+    display: flex;
+    flex-flow: column;
+    flex: 1;
+    justify-content: center;
+    padding: 1em 2em;
+    input[type="text"] {
+      @extend .comment;
+      display: block;
+      min-width: 100%;
+      border: none;
+    }
+    input[type="submit"] {
+      @include button();
+      align-self: flex-end;
+      margin-top: $baseline;
+      padding: $baseline $spacer;
+      background: $palette-accent;
+      color: $palette-lighter;
+    }
   }
 }
+
+
 
 .username-overlay {
   position: fixed;

--- a/client/src/components/comment-label/comment-label.js
+++ b/client/src/components/comment-label/comment-label.js
@@ -9,9 +9,6 @@ const css = classNames.bind(submitFieldStyles)
 const CommentLabel = ({ posterRole }) => (
   posterRole === 'op' ? (
     <>
-      <div className={css('dev-label')}>
-        DEV
-      </div>
       <div className={css('badge-container')}>
         <div className={css('badge')}>
           <div className={css('badge')}>
@@ -20,8 +17,8 @@ const CommentLabel = ({ posterRole }) => (
         </div>
       </div>
     </>
-  ) : (
-    <div className={css('dev-label', posterRole)}>
+  ) : ( // TODO: check if dev, not just else
+    <div className={css('developer-label')}>
       {posterRole.toUpperCase()}
     </div>
   )

--- a/client/src/components/comment-label/comment-label.js
+++ b/client/src/components/comment-label/comment-label.js
@@ -1,0 +1,18 @@
+import React from 'react'
+
+// Helpers
+import classNames from 'classnames/bind'
+
+
+// Styles
+import submitFieldStyles from './comment-label.scss'
+
+const css = classNames.bind(submitFieldStyles)
+
+const CommentLabel = ({ posterRole }) => (
+  <div className={css('comment-label', posterRole)}>
+    {posterRole}
+  </div>
+)
+
+export default CommentLabel

--- a/client/src/components/comment-label/comment-label.js
+++ b/client/src/components/comment-label/comment-label.js
@@ -11,7 +11,7 @@ const css = classNames.bind(submitFieldStyles)
 
 const CommentLabel = ({ posterRole }) => (
   <div className={css('comment-label', posterRole)}>
-    {posterRole}
+    {posterRole.toUpperCase()}
   </div>
 )
 

--- a/client/src/components/comment-label/comment-label.js
+++ b/client/src/components/comment-label/comment-label.js
@@ -1,18 +1,30 @@
 import React from 'react'
-
 // Helpers
 import classNames from 'classnames/bind'
-
-
 // Styles
 import submitFieldStyles from './comment-label.scss'
 
 const css = classNames.bind(submitFieldStyles)
 
 const CommentLabel = ({ posterRole }) => (
-  <div className={css('comment-label', posterRole)}>
-    {posterRole.toUpperCase()}
-  </div>
+  posterRole === 'op' ? (
+    <>
+      <div className={css('dev-label')}>
+        DEV
+      </div>
+      <div className={css('badge-container')}>
+        <div className={css('badge')}>
+          <div className={css('badge')}>
+            <div className={css('badge')} />
+          </div>
+        </div>
+      </div>
+    </>
+  ) : (
+    <div className={css('dev-label', posterRole)}>
+      {posterRole.toUpperCase()}
+    </div>
+  )
 )
 
 export default CommentLabel

--- a/client/src/components/comment-label/comment-label.scss
+++ b/client/src/components/comment-label/comment-label.scss
@@ -12,9 +12,11 @@
 }
 
 .dev {
-  background-color: green;
+  color: $palette-white;
+  background-color: $palette-dark;
 }
 
 .op {
-  background-color: dodgerblue;
+  color: $palette-white;
+  background-color: $palette-accent;
 }

--- a/client/src/components/comment-label/comment-label.scss
+++ b/client/src/components/comment-label/comment-label.scss
@@ -1,0 +1,20 @@
+@import '../../scss/variables';
+@import '../../scss/colors';
+@import '../../scss/mixins';
+@import '../../scss/atoms/button';
+
+.comment-label {
+  padding: .5 * $baseline;
+  border-radius: $border-radius-default;
+  background: $palette-white;
+  color: $palette-white;
+  @include shadow-outline(1px);
+}
+
+.dev {
+  background-color: green;
+}
+
+.op {
+  background-color: dodgerblue;
+}

--- a/client/src/components/comment-label/comment-label.scss
+++ b/client/src/components/comment-label/comment-label.scss
@@ -6,7 +6,6 @@
 .comment-label {
   padding: .5 * $baseline;
   border-radius: $border-radius-default;
-  background: $palette-white;
   color: $palette-white;
   @include shadow-outline(1px);
 }

--- a/client/src/components/comment-label/comment-label.scss
+++ b/client/src/components/comment-label/comment-label.scss
@@ -3,31 +3,31 @@
 @import '../../scss/mixins';
 @import '../../scss/atoms/button';
 
-%label {
-  display: inline-block;
-  margin-right: $spacer;
-}
 
-.dev-label {
-  @include shadow-outline(0px);
-  @extend %label;
-  padding: .5 * $baseline $spacer;
-  border-radius: $border-radius-default;
+.developer-label {
+  position: absolute;
+  left: -$baseline;
   font-size: $font-size-small;
-  background-color: $palette-white;
+  writing-mode: tb;
   color: $palette-accent;
 }
 
 $rotation: 30;
 
 .badge-container {
-  @extend %label;
+  $dimension: $baseline * 3;
+
+  position: absolute;
+  top: $baseline * 1.5;
+  left: $baseline * 1.5;
+  display: flex;
+  margin-right: $spacer;
+  z-index: 1;
 
   .badge {
-    $dimension: $baseline * 1.5;
     width: $dimension;
     height: $dimension;
-    background: $palette-accent;
+    background: $palette-badge-background;
     border-radius: 1px;
     transform: rotate(#{ $rotation }deg);
   }

--- a/client/src/components/comment-label/comment-label.scss
+++ b/client/src/components/comment-label/comment-label.scss
@@ -3,19 +3,32 @@
 @import '../../scss/mixins';
 @import '../../scss/atoms/button';
 
-.comment-label {
-  padding: .5 * $baseline;
+%label {
+  display: inline-block;
+  margin-right: $spacer;
+}
+
+.dev-label {
+  @include shadow-outline(0px);
+  @extend %label;
+  padding: .5 * $baseline $spacer;
   border-radius: $border-radius-default;
-  color: $palette-white;
-  @include shadow-outline(1px);
+  font-size: $font-size-small;
+  background-color: $palette-white;
+  color: $palette-accent;
 }
 
-.dev {
-  color: $palette-white;
-  background-color: $palette-dark;
-}
+$rotation: 30;
 
-.op {
-  color: $palette-white;
-  background-color: $palette-accent;
+.badge-container {
+  @extend %label;
+
+  .badge {
+    $dimension: $baseline * 1.5;
+    width: $dimension;
+    height: $dimension;
+    background: $palette-accent;
+    border-radius: 1px;
+    transform: rotate(#{ $rotation }deg);
+  }
 }

--- a/client/src/components/comment-panel/comment-panel.js
+++ b/client/src/components/comment-panel/comment-panel.js
@@ -13,6 +13,7 @@ import UsernameModal from '../add-username-modal/add-username-modal'
 import Thread from '../thread/thread'
 import apiCall from '../../api-call'
 import SubmitField from '../submit-field/submit-field'
+import ConfirmModal from '../confirm-modal/confirm-modal'
 // Styles
 import commentPanelStyles from './comment-panel.scss'
 // Assets
@@ -33,6 +34,7 @@ class CommentPanel extends React.Component {
     super(props)
     this.state = {
       usernameModalIsOpen: false,
+      commentToDelete: {},
       currentThread: '',
       isHidden: false,
     }
@@ -42,6 +44,7 @@ class CommentPanel extends React.Component {
     this.toggleUsernameModal = this.toggleUsernameModal.bind(this)
     this.handleClick = this.handleClick.bind(this)
     this.fetchComments = this.fetchComments.bind(this)
+    this.toggleDeleteModal = this.toggleDeleteModal.bind(this)
     this.deleteComment = this.deleteComment.bind(this)
     this.scrollToBottom = this.scrollToBottom.bind(this)
   }
@@ -103,7 +106,20 @@ class CommentPanel extends React.Component {
     await this.scrollToBottom()
   }
 
-  async deleteComment(comment) {
+  toggleDeleteModal(comment) {
+    console.log('TOGGLING: ', comment)
+    this.setState((prevState) => {
+      if (R.isEmpty(prevState.commentToDelete)) {
+        console.log('yes')
+        return { commentToDelete: comment }
+      }
+      return { commentToDelete: {} }
+    })
+    console.log('STATE: ', this.state.commentToDelete)
+  }
+
+  async deleteComment() {
+    const { commentToDelete: comment } = this.state
     if (Object.keys(this.props.users)[0] === comment.userId || this.props.role === 'dev') {
       await apiCall(
         'DELETE',
@@ -150,7 +166,7 @@ class CommentPanel extends React.Component {
                 handleSubmit={this.handleSubmit}
                 updateCurrentThread={this.updateCurrentThread}
                 currentThread={this.state.currentThread}
-                deleteComment={this.deleteComment}
+                deleteComment={this.toggleDeleteModal}
                 toggleTagElementState={this.props.toggleTagElementState}
               />),
             sortedThreads
@@ -187,8 +203,15 @@ class CommentPanel extends React.Component {
                 isOpen={this.state.usernameModalIsOpen}
                 toggle={this.toggleUsernameModal}
               />
-            ) : null
+            )
+              : null
           }
+          <ConfirmModal
+            text="Are you sure you want to delete this comment?"
+            action={this.deleteComment}
+            isOpen={!R.isEmpty(this.state.commentToDelete)}
+            toggle={this.toggleDeleteModal}
+          />
         </div>
       </div>
     )

--- a/client/src/components/comment-panel/comment-panel.js
+++ b/client/src/components/comment-panel/comment-panel.js
@@ -30,6 +30,7 @@ class CommentPanel extends React.Component {
     super(props)
     this.state = {
       value: '',
+      currentThread: '',
       isHidden: false,
     }
 
@@ -40,8 +41,12 @@ class CommentPanel extends React.Component {
     this.scrollToBottom = this.scrollToBottom.bind(this)
   }
 
-  handleChange(event) {
-    this.setState({ value: event.target.value })
+  handleChange(threadId, event) {
+    console.log('Handling: ', threadId, event)
+    this.setState({
+      value: event.target.value,
+      currentThread: threadId || '',
+    })
   }
 
   async handleSubmit(event) {
@@ -64,6 +69,7 @@ class CommentPanel extends React.Component {
     await apiCall('POST', '/comments', {
       text: this.state.value,
       blob: getBlob(),
+      threadId: this.state.currentThread || null,
     })
     unhighlightTaggedElement()
     this.props.unsetTaggedElement()
@@ -134,9 +140,9 @@ class CommentPanel extends React.Component {
         <div className={css('panel-body')}>
           { this.threadContainer() }
           <SubmitField
-            value={this.state.value}
+            value={this.state.currentThread ? '' : this.state.value}
             onSubmit={this.handleSubmit}
-            onChange={this.handleChange}
+            onChange={event => this.handleChange('', event)}
           />
 
         </div>

--- a/client/src/components/comment-panel/comment-panel.js
+++ b/client/src/components/comment-panel/comment-panel.js
@@ -42,7 +42,6 @@ class CommentPanel extends React.Component {
   }
 
   handleChange(threadId, event) {
-    console.log('Handling: ', threadId, event)
     this.setState({
       value: event.target.value,
       currentThread: threadId || '',

--- a/client/src/components/comment-panel/comment-panel.js
+++ b/client/src/components/comment-panel/comment-panel.js
@@ -34,6 +34,8 @@ class CommentPanel extends React.Component {
       isHidden: false,
     }
 
+    this.updateCurrentThread = this.updateCurrentThread.bind(this)
+    this.writeNewComment = this.writeNewComment.bind(this)
     this.handleChange = this.handleChange.bind(this)
     this.handleSubmit = this.handleSubmit.bind(this)
     this.handleClick = this.handleClick.bind(this)
@@ -41,11 +43,17 @@ class CommentPanel extends React.Component {
     this.scrollToBottom = this.scrollToBottom.bind(this)
   }
 
-  handleChange(threadId, event) {
-    this.setState({
-      value: event.target.value,
-      currentThread: threadId || '',
-    })
+  handleChange(event) {
+    this.setState({ value: event.target.value })
+  }
+
+  updateCurrentThread(threadId) {
+    this.setState({ currentThread: threadId })
+  }
+
+  writeNewComment(event) {
+    this.handleChange(event)
+    this.updateCurrentThread('')
   }
 
   async handleSubmit(event) {
@@ -115,6 +123,8 @@ class CommentPanel extends React.Component {
                 id={id}
                 onSubmit={this.handleSubmit}
                 onChange={this.handleChange}
+                updateCurrentThread={this.updateCurrentThread}
+                currentThread={this.state.currentThread}
               />),
             R.toPairs(threadArray)
           )
@@ -141,7 +151,7 @@ class CommentPanel extends React.Component {
           <SubmitField
             value={this.state.currentThread ? '' : this.state.value}
             onSubmit={this.handleSubmit}
-            onChange={event => this.handleChange('', event)}
+            onChange={this.writeNewComment}
           />
 
         </div>

--- a/client/src/components/comment-panel/comment-panel.js
+++ b/client/src/components/comment-panel/comment-panel.js
@@ -23,6 +23,7 @@ const css = classNames.bind(commentPanelStyles)
 
 const mapStateToProps = state => ({
   comments: state.comments,
+  users: (state.persist || {}).users || {},
   role: state.role,
 })
 
@@ -38,6 +39,7 @@ class CommentPanel extends React.Component {
     this.handleSubmit = this.handleSubmit.bind(this)
     this.handleClick = this.handleClick.bind(this)
     this.fetchComments = this.fetchComments.bind(this)
+    this.deleteComment = this.deleteComment.bind(this)
     this.scrollToBottom = this.scrollToBottom.bind(this)
   }
 
@@ -83,7 +85,14 @@ class CommentPanel extends React.Component {
   async fetchComments() {
     const comments = await apiCall('GET', '/comments')
     this.props.dispatch(loadComments(comments))
-    this.scrollToBottom()
+    await this.scrollToBottom()
+  }
+
+  async deleteComment(comment) {
+    if (Object.keys(this.props.users)[0] === comment.userId) {
+      await apiCall('DELETE', '/comments', { commentId: comment.id })
+      await this.fetchComments()
+    }
   }
 
   scrollToBottom() {
@@ -117,11 +126,12 @@ class CommentPanel extends React.Component {
                 key={id}
                 comments={comments}
                 id={id}
+                users={this.props.users}
                 role={this.props.role}
                 handleSubmit={this.handleSubmit}
-                onChange={this.handleChange}
                 updateCurrentThread={this.updateCurrentThread}
                 currentThread={this.state.currentThread}
+                deleteComment={this.deleteComment}
               />),
             sortedThreads
           )

--- a/client/src/components/comment-panel/comment-panel.js
+++ b/client/src/components/comment-panel/comment-panel.js
@@ -84,7 +84,7 @@ class CommentPanel extends React.Component {
   }
 
   scrollToBottom() {
-    const el = shadowDocument().getElementById('comment-container')
+    const el = shadowDocument().getElementById('thread--container')
     if (el) el.scrollTop = el.scrollHeight
   }
 
@@ -100,7 +100,7 @@ class CommentPanel extends React.Component {
     })
     const threadArray = groupByThread(Object.values(this.props.comments))
     return (
-      <div className={css('comment-container')} id="comment-container">
+      <div className={css('thread-container')} id="thread--container">
         {
           R.map(
             ([id, comments]) => <Thread key={id} comments={comments} id={id} />,

--- a/client/src/components/comment-panel/comment-panel.js
+++ b/client/src/components/comment-panel/comment-panel.js
@@ -35,6 +35,8 @@ class CommentPanel extends React.Component {
       isHidden: false,
     }
 
+    this.updateCurrentThread = this.updateCurrentThread.bind(this)
+    this.writeNewComment = this.writeNewComment.bind(this)
     this.handleChange = this.handleChange.bind(this)
     this.handleSubmit = this.handleSubmit.bind(this)
     this.handleClick = this.handleClick.bind(this)
@@ -42,11 +44,17 @@ class CommentPanel extends React.Component {
     this.scrollToBottom = this.scrollToBottom.bind(this)
   }
 
-  handleChange(threadId, event) {
-    this.setState({
-      value: event.target.value,
-      currentThread: threadId || '',
-    })
+  handleChange(event) {
+    this.setState({ value: event.target.value })
+  }
+
+  updateCurrentThread(threadId) {
+    this.setState({ currentThread: threadId })
+  }
+
+  writeNewComment(event) {
+    this.handleChange(event)
+    this.updateCurrentThread('')
   }
 
   async handleSubmit(event) {
@@ -116,6 +124,8 @@ class CommentPanel extends React.Component {
                 id={id}
                 onSubmit={this.handleSubmit}
                 onChange={this.handleChange}
+                updateCurrentThread={this.updateCurrentThread}
+                currentThread={this.state.currentThread}
               />),
             R.toPairs(threadArray)
           )
@@ -142,7 +152,7 @@ class CommentPanel extends React.Component {
           <SubmitField
             value={this.state.currentThread ? '' : this.state.value}
             onSubmit={this.handleSubmit}
-            onChange={event => this.handleChange('', event)}
+            onChange={this.writeNewComment}
           />
         </div>
       </div>

--- a/client/src/components/comment-panel/comment-panel.js
+++ b/client/src/components/comment-panel/comment-panel.js
@@ -11,6 +11,7 @@ import { loadComments } from '../../actions'
 // Components
 import Comment from '../comment/comment'
 import apiCall from '../../api-call'
+import SubmitField from '../submit-field/submit-field'
 // Styles
 import commentPanelStyles from './comment-panel.scss'
 // Assets
@@ -120,14 +121,11 @@ class CommentPanel extends React.Component {
         </div>
         <div className={css('panel-body')}>
           { this.commentContainer() }
-          <form className={css('comment-form')} onSubmit={this.handleSubmit}>
-            <textarea
-              value={this.state.value}
-              onChange={this.handleChange}
-              placeholder="Write comment..."
-            />
-            <input className={css('submit-comment')} type="submit" value="Comment" />
-          </form>
+          <SubmitField
+            value={this.state.value}
+            onSubmit={this.handleSubmit}
+            onChange={this.handleChange}
+          />
         </div>
       </div>
     )

--- a/client/src/components/comment-panel/comment-panel.js
+++ b/client/src/components/comment-panel/comment-panel.js
@@ -115,6 +115,7 @@ class CommentPanel extends React.Component {
                 key={id}
                 comments={comments}
                 id={id}
+                role={this.props.role}
                 handleSubmit={this.handleSubmit}
                 onChange={this.handleChange}
                 updateCurrentThread={this.updateCurrentThread}
@@ -143,7 +144,7 @@ class CommentPanel extends React.Component {
         <div className={css('panel-body')}>
           { this.threadContainer() }
           <SubmitField
-            onSubmit={this.handleSubmit}
+            handleSubmit={this.handleSubmit}
             threadId=""
           />
         </div>

--- a/client/src/components/comment-panel/comment-panel.js
+++ b/client/src/components/comment-panel/comment-panel.js
@@ -33,7 +33,6 @@ class CommentPanel extends React.Component {
     super(props)
     this.state = {
       usernameModalIsOpen: false,
-      value: '',
       currentThread: '',
       isHidden: false,
     }
@@ -162,6 +161,7 @@ class CommentPanel extends React.Component {
   }
 
   render() {
+    console.log(this.props)
     return (
       <div className={css('panel-container', 'comment-panel', { hidden: this.state.isHidden })}>
         <div className={css('panel-header')}>

--- a/client/src/components/comment-panel/comment-panel.js
+++ b/client/src/components/comment-panel/comment-panel.js
@@ -85,7 +85,7 @@ class CommentPanel extends React.Component {
   }
 
   scrollToBottom() {
-    const el = shadowDocument().getElementById('comment-container')
+    const el = shadowDocument().getElementById('thread--container')
     if (el) el.scrollTop = el.scrollHeight
   }
 
@@ -101,7 +101,7 @@ class CommentPanel extends React.Component {
     })
     const threadArray = groupByThread(Object.values(this.props.comments))
     return (
-      <div className={css('comment-container')} id="comment-container">
+      <div className={css('thread-container')} id="thread--container">
         {
           R.map(
             ([id, comments]) => <Thread key={id} comments={comments} id={id} />,

--- a/client/src/components/comment-panel/comment-panel.js
+++ b/client/src/components/comment-panel/comment-panel.js
@@ -103,7 +103,14 @@ class CommentPanel extends React.Component {
       <div className={css('thread-container')} id="thread--container">
         {
           R.map(
-            ([id, comments]) => <Thread key={id} comments={comments} id={id} />,
+            ([id, comments]) => (
+              <Thread
+                key={id}
+                comments={comments}
+                id={id}
+                onSubmit={this.handleSubmit}
+                onChange={this.handleChange}
+              />),
             R.toPairs(threadArray)
           )
         }

--- a/client/src/components/comment-panel/comment-panel.js
+++ b/client/src/components/comment-panel/comment-panel.js
@@ -11,6 +11,7 @@ import { loadComments } from '../../actions'
 // Components
 import Comment from '../comment/comment'
 import apiCall from '../../api-call'
+import SubmitField from '../submit-field/submit-field'
 // Styles
 import commentPanelStyles from './comment-panel.scss'
 // Assets
@@ -118,14 +119,11 @@ class CommentPanel extends React.Component {
         </div>
         <div className={css('panel-body')}>
           { this.commentContainer() }
-          <form className={css('comment-form')} onSubmit={this.handleSubmit}>
-            <textarea
-              value={this.state.value}
-              onChange={this.handleChange}
-              placeholder="Write comment..."
-            />
-            <input className={css('submit-comment')} type="submit" value="Comment" />
-          </form>
+          <SubmitField
+            value={this.state.value}
+            onSubmit={this.handleSubmit}
+            onChange={this.handleChange}
+          />
         </div>
       </div>
     )

--- a/client/src/components/comment-panel/comment-panel.js
+++ b/client/src/components/comment-panel/comment-panel.js
@@ -31,6 +31,7 @@ class CommentPanel extends React.Component {
     super(props)
     this.state = {
       value: '',
+      currentThread: '',
       isHidden: false,
     }
 
@@ -41,8 +42,12 @@ class CommentPanel extends React.Component {
     this.scrollToBottom = this.scrollToBottom.bind(this)
   }
 
-  handleChange(event) {
-    this.setState({ value: event.target.value })
+  handleChange(threadId, event) {
+    console.log('Handling: ', threadId, event)
+    this.setState({
+      value: event.target.value,
+      currentThread: threadId || '',
+    })
   }
 
   async handleSubmit(event) {
@@ -65,6 +70,7 @@ class CommentPanel extends React.Component {
     await apiCall('POST', '/comments', {
       text: this.state.value,
       blob: getBlob(),
+      threadId: this.state.currentThread || null,
     })
     unhighlightTaggedElement()
     this.props.unsetTaggedElement()
@@ -135,9 +141,9 @@ class CommentPanel extends React.Component {
         <div className={css('panel-body')}>
           { this.threadContainer() }
           <SubmitField
-            value={this.state.value}
+            value={this.state.currentThread ? '' : this.state.value}
             onSubmit={this.handleSubmit}
-            onChange={this.handleChange}
+            onChange={event => this.handleChange('', event)}
           />
         </div>
       </div>

--- a/client/src/components/comment-panel/comment-panel.js
+++ b/client/src/components/comment-panel/comment-panel.js
@@ -181,14 +181,14 @@ class CommentPanel extends React.Component {
             threadId=""
             toggleTagElementState={this.props.toggleTagElementState}
           />
-          {!this.props.users.name
-            ? (
+          {
+            !this.props.users.name ? (
               <UsernameModal
                 isOpen={this.state.usernameModalIsOpen}
                 toggle={this.toggleUsernameModal}
               />
-            )
-            : null}
+            ) : null
+          }
         </div>
       </div>
     )

--- a/client/src/components/comment-panel/comment-panel.js
+++ b/client/src/components/comment-panel/comment-panel.js
@@ -96,7 +96,7 @@ class CommentPanel extends React.Component {
   }
 
   scrollToBottom() {
-    const el = shadowDocument().getElementById('thread--container')
+    const el = shadowDocument().getElementById('thread-container')
     if (el) el.scrollTop = el.scrollHeight
   }
 
@@ -118,7 +118,7 @@ class CommentPanel extends React.Component {
     ).time)
     const sortedThreads = sortbyTime(R.toPairs(threadArray))
     return (
-      <div className={css('thread-container')} id="thread--container">
+      <div className={css('thread-container')} id="thread-container">
         {
           R.map(
             ([id, comments]) => (

--- a/client/src/components/comment-panel/comment-panel.js
+++ b/client/src/components/comment-panel/comment-panel.js
@@ -30,34 +30,22 @@ class CommentPanel extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
-      value: '',
       currentThread: '',
       isHidden: false,
     }
 
     this.updateCurrentThread = this.updateCurrentThread.bind(this)
-    this.writeNewComment = this.writeNewComment.bind(this)
-    this.handleChange = this.handleChange.bind(this)
     this.handleSubmit = this.handleSubmit.bind(this)
     this.handleClick = this.handleClick.bind(this)
     this.fetchComments = this.fetchComments.bind(this)
     this.scrollToBottom = this.scrollToBottom.bind(this)
   }
 
-  handleChange(event) {
-    this.setState({ value: event.target.value })
-  }
-
   updateCurrentThread(threadId) {
     this.setState({ currentThread: threadId })
   }
 
-  writeNewComment(event) {
-    this.handleChange(event)
-    this.updateCurrentThread('')
-  }
-
-  async handleSubmit(event) {
+  async handleSubmit(event, value, threadId) {
     event.preventDefault()
     event.nativeEvent.stopImmediatePropagation()
 
@@ -75,13 +63,12 @@ class CommentPanel extends React.Component {
     }
 
     await apiCall('POST', '/comments', {
-      text: this.state.value,
+      text: value,
       blob: getBlob(),
-      threadId: this.state.currentThread || null,
+      threadId: threadId || null,
     })
     unhighlightTaggedElement()
     this.props.unsetTaggedElement()
-    this.setState({ value: '' })
     await this.fetchComments()
   }
 
@@ -113,6 +100,12 @@ class CommentPanel extends React.Component {
       }
     })
     const threadArray = groupByThread(Object.values(this.props.comments))
+    const sortbyTime = R.sortBy(([id, comments]) => R.reduce(
+      R.minBy(comment => comment.time),
+      { time: '9999-99-99 99:99:99' },
+      comments
+    ).time)
+    const sortedThreads = sortbyTime(R.toPairs(threadArray))
     return (
       <div className={css('thread-container')} id="thread--container">
         {
@@ -122,12 +115,12 @@ class CommentPanel extends React.Component {
                 key={id}
                 comments={comments}
                 id={id}
-                onSubmit={this.handleSubmit}
+                handleSubmit={this.handleSubmit}
                 onChange={this.handleChange}
                 updateCurrentThread={this.updateCurrentThread}
                 currentThread={this.state.currentThread}
               />),
-            R.toPairs(threadArray)
+            sortedThreads
           )
         }
       </div>
@@ -150,9 +143,8 @@ class CommentPanel extends React.Component {
         <div className={css('panel-body')}>
           { this.threadContainer() }
           <SubmitField
-            value={this.state.currentThread ? '' : this.state.value}
             onSubmit={this.handleSubmit}
-            onChange={this.writeNewComment}
+            threadId=""
           />
         </div>
       </div>

--- a/client/src/components/comment-panel/comment-panel.js
+++ b/client/src/components/comment-panel/comment-panel.js
@@ -43,7 +43,6 @@ class CommentPanel extends React.Component {
   }
 
   handleChange(threadId, event) {
-    console.log('Handling: ', threadId, event)
     this.setState({
       value: event.target.value,
       currentThread: threadId || '',

--- a/client/src/components/comment-panel/comment-panel.js
+++ b/client/src/components/comment-panel/comment-panel.js
@@ -9,7 +9,7 @@ import * as DomTagging from '../../dom-tagging'
 import { loadComments } from '../../actions'
 
 // Components
-import Comment from '../comment/comment'
+import Thread from '../thread/thread'
 import apiCall from '../../api-call'
 import SubmitField from '../submit-field/submit-field'
 // Styles
@@ -88,16 +88,23 @@ class CommentPanel extends React.Component {
     if (el) el.scrollTop = el.scrollHeight
   }
 
-  commentContainer() {
+  threadContainer() {
     if (R.isEmpty(this.props.comments)) return (<p>No comments fetched.</p>)
-    const sortByTime = R.sortBy(arr => arr[1].time)
-    const sortedCommentArray = sortByTime(R.toPairs(this.props.comments))
+    const threadIds = new Set(Object.values(this.props.comments).map(comment => comment.threadId))
+    const groupByThread = R.groupBy((comment) => {
+      for (const id of threadIds) {
+        if (comment.threadId === id) {
+          return id
+        }
+      }
+    })
+    const threadArray = groupByThread(Object.values(this.props.comments))
     return (
       <div className={css('comment-container')} id="comment-container">
         {
           R.map(
-            ([id, comment]) => <Comment key={id} comment={comment} id={id} />,
-            sortedCommentArray
+            ([id, comments]) => <Thread key={id} comments={comments} id={id} />,
+            R.toPairs(threadArray)
           )
         }
       </div>
@@ -118,12 +125,13 @@ class CommentPanel extends React.Component {
           </button>
         </div>
         <div className={css('panel-body')}>
-          { this.commentContainer() }
+          { this.threadContainer() }
           <SubmitField
             value={this.state.value}
             onSubmit={this.handleSubmit}
             onChange={this.handleChange}
           />
+
         </div>
       </div>
     )

--- a/client/src/components/comment-panel/comment-panel.js
+++ b/client/src/components/comment-panel/comment-panel.js
@@ -89,8 +89,12 @@ class CommentPanel extends React.Component {
   }
 
   async deleteComment(comment) {
-    if (Object.keys(this.props.users)[0] === comment.userId) {
-      await apiCall('DELETE', '/comments', { commentId: comment.id })
+    if (Object.keys(this.props.users)[0] === comment.userId || this.props.role === 'dev') {
+      await apiCall(
+        'DELETE',
+        '/comments',
+        { commentId: comment.id, commentUser: comment.userId }
+      )
       await this.fetchComments()
     }
   }

--- a/client/src/components/comment-panel/comment-panel.js
+++ b/client/src/components/comment-panel/comment-panel.js
@@ -47,14 +47,14 @@ class CommentPanel extends React.Component {
     this.setState({ currentThread: threadId })
   }
 
-  async handleSubmit(event, value, threadId) {
+  async handleSubmit(event, taggedElementXPath, value, threadId) {
     event.preventDefault()
     event.nativeEvent.stopImmediatePropagation()
 
     if (value === '') return // Don't post empty comment
 
     const getBlob = () => {
-      const xPath = this.props.taggedElementXPath
+      const xPath = taggedElementXPath
       if (xPath) {
         return { xPath }
       }
@@ -132,6 +132,7 @@ class CommentPanel extends React.Component {
                 updateCurrentThread={this.updateCurrentThread}
                 currentThread={this.state.currentThread}
                 deleteComment={this.deleteComment}
+                toggleTagElementState={this.props.toggleTagElementState}
               />),
             sortedThreads
           )
@@ -158,6 +159,7 @@ class CommentPanel extends React.Component {
           <SubmitField
             handleSubmit={this.handleSubmit}
             threadId=""
+            toggleTagElementState={this.props.toggleTagElementState}
           />
         </div>
       </div>

--- a/client/src/components/comment-panel/comment-panel.js
+++ b/client/src/components/comment-panel/comment-panel.js
@@ -49,6 +49,8 @@ class CommentPanel extends React.Component {
     event.preventDefault()
     event.nativeEvent.stopImmediatePropagation()
 
+    if (value === '') return // Don't post empty comment
+
     const getBlob = () => {
       const xPath = this.props.taggedElementXPath
       if (xPath) {

--- a/client/src/components/comment-panel/comment-panel.js
+++ b/client/src/components/comment-panel/comment-panel.js
@@ -146,7 +146,7 @@ class CommentPanel extends React.Component {
       }
     })
     const threadArray = groupByThread(Object.values(this.props.comments))
-    const sortbyTime = R.sortBy(([id, comments]) => R.reduce(
+    const sortbyTime = R.sortBy(([comments]) => R.reduce(
       R.minBy(comment => comment.time),
       { time: '9999-99-99 99:99:99' },
       comments
@@ -177,7 +177,6 @@ class CommentPanel extends React.Component {
   }
 
   render() {
-    console.log(this.props)
     return (
       <div className={css('panel-container', 'comment-panel', { hidden: this.state.isHidden })}>
         <div className={css('panel-header')}>

--- a/client/src/components/comment-panel/comment-panel.js
+++ b/client/src/components/comment-panel/comment-panel.js
@@ -104,7 +104,14 @@ class CommentPanel extends React.Component {
       <div className={css('thread-container')} id="thread--container">
         {
           R.map(
-            ([id, comments]) => <Thread key={id} comments={comments} id={id} />,
+            ([id, comments]) => (
+              <Thread
+                key={id}
+                comments={comments}
+                id={id}
+                onSubmit={this.handleSubmit}
+                onChange={this.handleChange}
+              />),
             R.toPairs(threadArray)
           )
         }

--- a/client/src/components/comment-panel/comment-panel.js
+++ b/client/src/components/comment-panel/comment-panel.js
@@ -9,7 +9,7 @@ import * as DomTagging from '../../dom-tagging'
 import { loadComments } from '../../actions'
 
 // Components
-import Comment from '../comment/comment'
+import Thread from '../thread/thread'
 import apiCall from '../../api-call'
 import SubmitField from '../submit-field/submit-field'
 // Styles
@@ -89,17 +89,23 @@ class CommentPanel extends React.Component {
     if (el) el.scrollTop = el.scrollHeight
   }
 
-  commentContainer() {
+  threadContainer() {
     if (R.isEmpty(this.props.comments)) return (<p>No comments fetched.</p>)
-    const { role } = this.props
-    const sortByTime = R.sortBy(arr => arr[1].time)
-    const sortedCommentArray = sortByTime(R.toPairs(this.props.comments))
+    const threadIds = new Set(Object.values(this.props.comments).map(comment => comment.threadId))
+    const groupByThread = R.groupBy((comment) => {
+      for (const id of threadIds) {
+        if (comment.threadId === id) {
+          return id
+        }
+      }
+    })
+    const threadArray = groupByThread(Object.values(this.props.comments))
     return (
       <div className={css('comment-container')} id="comment-container">
         {
           R.map(
-            ([id, comment]) => <Comment key={id} comment={comment} id={id} role={role} />,
-            sortedCommentArray
+            ([id, comments]) => <Thread key={id} comments={comments} id={id} />,
+            R.toPairs(threadArray)
           )
         }
       </div>
@@ -120,7 +126,7 @@ class CommentPanel extends React.Component {
           </button>
         </div>
         <div className={css('panel-body')}>
-          { this.commentContainer() }
+          { this.threadContainer() }
           <SubmitField
             value={this.state.value}
             onSubmit={this.handleSubmit}

--- a/client/src/components/comment-panel/comment-panel.scss
+++ b/client/src/components/comment-panel/comment-panel.scss
@@ -38,7 +38,7 @@ $panel-min-width: 300px;
   justify-content: flex-start;
 }
 
-.comment-container {
+.thread-container {
   display: flex;
   flex-flow: column;
   flex-grow: 1;

--- a/client/src/components/comment-panel/comment-panel.scss
+++ b/client/src/components/comment-panel/comment-panel.scss
@@ -49,35 +49,3 @@ $panel-min-width: 300px;
   padding: $baseline;
   margin: 0 (-$baseline);
 }
-
-.comment-form {
-  display: flex;
-  flex-flow: column;
-  flex-shrink: 0;
-  flex-grow: 0;
-  justify-content: center;
-  margin-top: $baseline;
-
-  textarea {
-    @extend .comment;
-    display: block;
-    max-width: 100%;
-    min-width: $panel-min-width;
-    min-height: 3em;
-    border: none;
-
-    &:focus {
-      outline: none;
-      box-shadow: 0 2px 10px $palette-shadow-default;
-    }
-  }
-
-  .submit-comment {
-    @include button();
-    align-self: flex-end;
-    margin-top: $baseline;
-    padding: $baseline $spacer;
-    background: $palette-accent;
-    color: $palette-lighter;
-  }
-}

--- a/client/src/components/comment-panel/comment-panel.scss
+++ b/client/src/components/comment-panel/comment-panel.scss
@@ -10,7 +10,7 @@ $panel-min-width: 300px;
 
 .comment-panel {
   min-width: $panel-min-width;
-  max-width: 50%;
+  max-width: $panel-min-width;
   height: 100%;
 
   position: fixed;

--- a/client/src/components/comment/comment.js
+++ b/client/src/components/comment/comment.js
@@ -40,13 +40,17 @@ const targetElement = (comment) => {
   }
 }
 
-const chooseLabel = (op, userId) => {
+const opLabel = (op, userId) => {
   if (userId === op) {
-    return (
-      <div className={css('label-container')}>
-        <CommentLabel posterRole="op" />
-      </div>
-    )
+    return <CommentLabel posterRole="op" />
+  }
+  return null
+}
+
+// TODO: refactor
+const devLabel = () => {
+  if (true) {
+    return <CommentLabel posterRole="Developer" />
   }
   return null
 }
@@ -55,10 +59,11 @@ const Comment = ({ id, comment, role, op, onClick, buttonText, canDelete, delete
   <div className={css('comment', { dev: role === 'dev' })} key={id}>
     <div className={css('header')}>
       <div className={css('name-label-container')}>
+        {devLabel()}
         <div className={css('name')}>
           {comment.username || 'Anonymous user'}
         </div>
-        {chooseLabel(op, comment.userId)}
+        {opLabel(op, comment.userId)}
       </div>
       <div className={css('time-target-container')}>
         <Moment className={css('timestamp')} fromNow>{comment.time}</Moment>
@@ -71,14 +76,18 @@ const Comment = ({ id, comment, role, op, onClick, buttonText, canDelete, delete
       </div>
     </div>
     <Reactions reactions={comment.reactions} commentId={id} />
-    <div className={css('expand-button-container')}>
-      <button
-        className={css('delete-button', { hidden: !canDelete })}
-        type="button"
-        onClick={() => deleteComment(comment)}
-      >
-        Delete
-      </button>
+    <div className={css('actions-container')}>
+      {
+        canDelete ? (
+          <button
+            className={css('delete-button')}
+            type="button"
+            onClick={() => deleteComment(comment)}
+          >
+            Delete
+          </button>
+        ) : null
+      }
       <button type="button" onClick={onClick}>{buttonText}</button>
     </div>
   </div>

--- a/client/src/components/comment/comment.js
+++ b/client/src/components/comment/comment.js
@@ -42,7 +42,7 @@ const targetElement = (comment) => {
 
 const chooseLabel = (op, userId) => {
   if (userId === op) {
-    return <CommentLabel posterRole="OP" />
+    return <CommentLabel posterRole="op" />
   }
   return null
 }

--- a/client/src/components/comment/comment.js
+++ b/client/src/components/comment/comment.js
@@ -1,8 +1,8 @@
 import React from 'react'
+// Helpers
 import Moment from 'react-moment'
 import * as R from 'ramda'
 import InlineSVG from 'svg-inline-react'
-// Helpers
 import classNames from 'classnames/bind'
 import * as DomTagging from '../../dom-tagging'
 // Components
@@ -42,7 +42,7 @@ const targetElement = (comment) => {
 
 const chooseLabel = (op, userId) => {
   if (userId === op) {
-    return <CommentLabel posterRole="op" />
+    return <CommentLabel posterRole="OP" />
   }
   return null
 }
@@ -62,7 +62,13 @@ const Comment = ({ id, comment, role, op, onClick, buttonText, canDelete, delete
     </div>
     <Reactions reactions={comment.reactions} commentId={id} />
     <div className={css('expand-button-container')}>
-      <button className={css('delete-button', { hidden: !canDelete })} type="button" onClick={() => deleteComment(comment)}>Delete</button>
+      <button
+        className={css('delete-button', { hidden: !canDelete })}
+        type="button"
+        onClick={() => deleteComment(comment)}
+      >
+        Delete
+      </button>
       <button type="button" onClick={onClick}>{buttonText}</button>
     </div>
   </div>

--- a/client/src/components/comment/comment.js
+++ b/client/src/components/comment/comment.js
@@ -50,7 +50,7 @@ const chooseLabel = (op, userId) => {
 const Comment = ({ id, comment, role, op, onClick, buttonText, canDelete, deleteComment }) => (
   <div className={css('comment', { dev: role === 'dev' })} key={id}>
     <div className={css('header')}>
-      <div className={css('name')}>Anonymous user</div>
+      <div className={css('name')}>{comment.username || 'Anonymous user'}</div>
       {chooseLabel(op, comment.userId)}
       <Moment className={css('timestamp')} fromNow>{comment.time}</Moment>
       { targetElement(comment) }

--- a/client/src/components/comment/comment.js
+++ b/client/src/components/comment/comment.js
@@ -47,7 +47,7 @@ const chooseLabel = (op, userId) => {
   return null
 }
 
-const Comment = ({ id, comment, role, op }) => (
+const Comment = ({ id, comment, role, op, onClick, buttonText }) => (
   <div className={css('comment', { dev: role === 'dev' })} key={id}>
     <div className={css('header')}>
       <div className={css('name')}>Anonymous user</div>
@@ -61,6 +61,10 @@ const Comment = ({ id, comment, role, op }) => (
       </div>
     </div>
     <Reactions reactions={comment.reactions} commentId={id} />
+    <div className={css('expand-button-container')}>
+      <button type="button">Delete</button>
+      <button type="button" onClick={onClick}>{buttonText}</button>
+    </div>
   </div>
 )
 

--- a/client/src/components/comment/comment.js
+++ b/client/src/components/comment/comment.js
@@ -42,7 +42,11 @@ const targetElement = (comment) => {
 
 const chooseLabel = (op, userId) => {
   if (userId === op) {
-    return <CommentLabel posterRole="op" />
+    return (
+      <div className={css('label-container')}>
+        <CommentLabel posterRole="op" />
+      </div>
+    )
   }
   return null
 }
@@ -50,10 +54,16 @@ const chooseLabel = (op, userId) => {
 const Comment = ({ id, comment, role, op, onClick, buttonText, canDelete, deleteComment }) => (
   <div className={css('comment', { dev: role === 'dev' })} key={id}>
     <div className={css('header')}>
-      <div className={css('name')}>Anonymous user</div>
-      {chooseLabel(op, comment.userId)}
-      <Moment className={css('timestamp')} fromNow>{comment.time}</Moment>
-      { targetElement(comment) }
+      <div className={css('name-label-container')}>
+        <div className={css('name')}>
+          Anonymous user
+        </div>
+        {chooseLabel(op, comment.userId)}
+      </div>
+      <div className={css('time-target-container')}>
+        <Moment className={css('timestamp')} fromNow>{comment.time}</Moment>
+        {targetElement(comment)}
+      </div>
     </div>
     <div className={css('body')}>
       <div className={css('text')}>

--- a/client/src/components/comment/comment.js
+++ b/client/src/components/comment/comment.js
@@ -1,9 +1,9 @@
 import React from 'react'
-// Helpers
-import * as R from 'ramda'
-import classNames from 'classnames/bind'
-import InlineSVG from 'svg-inline-react'
 import Moment from 'react-moment'
+import * as R from 'ramda'
+import InlineSVG from 'svg-inline-react'
+// Helpers
+import classNames from 'classnames/bind'
 import * as DomTagging from '../../dom-tagging'
 // Components
 import Reactions from '../reactions/reactions'
@@ -47,7 +47,7 @@ const chooseLabel = (op, userId) => {
   return null
 }
 
-const Comment = ({ id, comment, role, op, onClick, buttonText }) => (
+const Comment = ({ id, comment, role, op, onClick, buttonText, canDelete, deleteComment }) => (
   <div className={css('comment', { dev: role === 'dev' })} key={id}>
     <div className={css('header')}>
       <div className={css('name')}>Anonymous user</div>
@@ -62,7 +62,7 @@ const Comment = ({ id, comment, role, op, onClick, buttonText }) => (
     </div>
     <Reactions reactions={comment.reactions} commentId={id} />
     <div className={css('expand-button-container')}>
-      <button type="button">Delete</button>
+      <button className={css('delete-button', { hidden: !canDelete })} type="button" onClick={() => deleteComment(comment)}>Delete</button>
       <button type="button" onClick={onClick}>{buttonText}</button>
     </div>
   </div>

--- a/client/src/components/comment/comment.js
+++ b/client/src/components/comment/comment.js
@@ -4,10 +4,10 @@ import * as R from 'ramda'
 import classNames from 'classnames/bind'
 import InlineSVG from 'svg-inline-react'
 import Moment from 'react-moment'
-import moment from 'moment-timezone'
 import * as DomTagging from '../../dom-tagging'
 // Components
 import Reactions from '../reactions/reactions'
+import CommentLabel from '../comment-label/comment-label'
 // Styles
 import styles from './comment.scss'
 // Assets
@@ -40,16 +40,19 @@ const targetElement = (comment) => {
   }
 }
 
-const Comment = ({ id, comment, role }) => (
+const chooseLabel = (op, userId) => {
+  if (userId === op) {
+    return <CommentLabel posterRole="op" />
+  }
+  return null
+}
+
+const Comment = ({ id, comment, role, op }) => (
   <div className={css('comment', { dev: role === 'dev' })} key={id}>
     <div className={css('header')}>
       <div className={css('name')}>Anonymous user</div>
-      <Moment
-        className={css('timestamp')}
-        date={comment.time}
-        format="D.MM.YYYY HH:mm"
-        tz={moment.tz.guess()}
-      />
+      {chooseLabel(op, comment.userId)}
+      <Moment className={css('timestamp')} fromNow>{comment.time}</Moment>
       { targetElement(comment) }
     </div>
     <div className={css('body')}>

--- a/client/src/components/comment/comment.scss
+++ b/client/src/components/comment/comment.scss
@@ -90,3 +90,7 @@
     }
   }
 }
+
+.name-label-container {
+  display: none; // TODO: NOT IN USE CURRENTLY
+}

--- a/client/src/components/comment/comment.scss
+++ b/client/src/components/comment/comment.scss
@@ -52,3 +52,17 @@
     font-size: $font-size-small;
   }
 }
+
+.expand-button-container {
+  display: flex;
+  justify-content: center;
+
+  button {
+    @include button();
+    background: white;
+    @include shadow-outline(1px);
+    position: relative;
+    top: $baseline;
+    margin-right: $spacer;
+  }
+}

--- a/client/src/components/comment/comment.scss
+++ b/client/src/components/comment/comment.scss
@@ -64,6 +64,10 @@
 
   .text {
     margin-top: $baseline;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    word-break: break-word;
+    hyphens: auto;
   }
 
   .timestamp {

--- a/client/src/components/comment/comment.scss
+++ b/client/src/components/comment/comment.scss
@@ -55,7 +55,7 @@
 
 .expand-button-container {
   display: flex;
-  justify-content: center;
+  justify-content: flex-end;
 
   button {
     @include button();
@@ -64,5 +64,9 @@
     position: relative;
     top: $baseline;
     margin-right: $spacer;
+
+    &.hidden {
+      display: none;
+    }
   }
 }

--- a/client/src/components/comment/comment.scss
+++ b/client/src/components/comment/comment.scss
@@ -3,6 +3,30 @@
 @import '../../scss/mixins';
 @import '../../scss/atoms/button';
 
+%target-icon {
+  @include reset-button();
+  display: flex;
+  cursor: pointer;
+
+  svg {
+    $target-icon-dimension: $icon-dimension-default / 2;
+    width: $target-icon-dimension;
+    height: $target-icon-dimension;
+    fill: $palette-dark;
+    transition: fill $transition-default-tail
+  }
+
+  &:hover svg {
+    fill: $palette-black;
+    transition: fill $transition-default-tail
+  }
+
+  &:focus svg {
+    fill: $palette-accent;
+    transition: fill $transition-default-tail
+  }
+}
+
 .comment {
   margin-top: $spacer;
   padding: $spacer;
@@ -21,26 +45,7 @@
   }
 
   .target-icon {
-    @include reset-button();
-    cursor: pointer;
-
-    svg {
-      $target-icon-dimension: $icon-dimension-default / 2;
-      width: $target-icon-dimension;
-      height: $target-icon-dimension;
-      fill: $palette-dark;
-      transition: fill $transition-default-tail
-    }
-
-    &:hover svg {
-      fill: $palette-black;
-      transition: fill $transition-default-tail
-    }
-
-    &:focus svg {
-      fill: $palette-accent;
-      transition: fill $transition-default-tail
-    }
+    @extend %target-icon;
   }
 
   .text {
@@ -63,7 +68,8 @@
     @include shadow-outline(1px);
     position: relative;
     top: $baseline;
-    margin-right: $spacer;
+    margin-left: $baseline;
+    margin-right: 1px; // Shadow-outline fix
 
     &.hidden {
       display: none;

--- a/client/src/components/comment/comment.scss
+++ b/client/src/components/comment/comment.scss
@@ -28,6 +28,7 @@
 }
 
 .comment {
+  position: relative; // For labels
   margin-top: $spacer;
   padding: $spacer;
   border-radius: $border-radius-default;
@@ -42,14 +43,14 @@
     display: flex;
     align-items: flex-start;
 
-    .name-label-container {
-      .label-container {
-        display: flex;
-        margin-top: $baseline;
-        align-items: center;
-      }
+    // For labels
+    .name {
+      position: relative;
+      margin-bottom: $baseline;
+      z-index: 2;
     }
 
+    // When name wraps => still at top but time & target centered
     .time-target-container {
       display: flex;
       align-items: center;
@@ -71,21 +72,21 @@
   }
 }
 
-.expand-button-container {
+.actions-container {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
 
   button {
-    @include button();
-    background: white;
-    @include shadow-outline(1px);
-    position: relative;
-    top: $baseline;
-    margin-left: $baseline;
-    margin-right: 1px; // Shadow-outline fix
+    @include reset-button();
+    margin: $spacer 1px 0 0; // 1px for shadow-outline fix
+    color: $palette-medium;
 
     &.hidden {
       display: none;
+    }
+
+    &:only-of-type {
+      margin-left: auto;
     }
   }
 }

--- a/client/src/components/comment/comment.scss
+++ b/client/src/components/comment/comment.scss
@@ -40,8 +40,21 @@
 
   .header {
     display: flex;
-    justify-content: space-between;
-    align-items: center;
+    align-items: flex-start;
+
+    .name-label-container {
+      .label-container {
+        display: flex;
+        margin-top: $baseline;
+        align-items: center;
+      }
+    }
+
+    .time-target-container {
+      display: flex;
+      align-items: center;
+      margin-left: auto;
+    }
   }
 
   .target-icon {
@@ -53,7 +66,7 @@
   }
 
   .timestamp {
-    align-self: flex-end;
+    margin-right: $baseline;
     font-size: $font-size-small;
   }
 }

--- a/client/src/components/confirm-modal/confirm-modal.js
+++ b/client/src/components/confirm-modal/confirm-modal.js
@@ -1,0 +1,52 @@
+import React from 'react'
+import ReactModal from 'react-modal'
+
+import classNames from 'classnames/bind'
+
+import { shadowModalRoot } from '../../shadowDomHelper'
+
+import styles from './confirm-modal.scss'
+
+const css = classNames.bind(styles)
+
+const ConfirmModal = ({ text, action, isOpen, toggle }) => (
+  <ReactModal
+    className={css('confirm-modal')}
+    isOpen={isOpen}
+    parentSelector={shadowModalRoot}
+    overlayClassName={css('confirm-overlay')}
+    onRequestClose={toggle}
+    shouldFocusAfterRender
+    shouldCloseOnOverlayClick
+    shouldCloseOnEsc
+  >
+    <h4 className={css('header')}>Confirm</h4>
+    <div className={css('body')}>
+      <div className={css('text')}>
+        {text}
+      </div>
+    </div>
+    <div className={css('button-container')}>
+      <button
+        type="button"
+        className={css('confirm-button')}
+        onClick={() => {
+          action()
+          toggle()
+        }
+        }
+      >
+        Yes
+      </button>
+      <button
+        type="button"
+        className={css('confirm-button')}
+        onClick={toggle}
+      >
+        No
+      </button>
+    </div>
+  </ReactModal>
+)
+
+export default ConfirmModal

--- a/client/src/components/confirm-modal/confirm-modal.scss
+++ b/client/src/components/confirm-modal/confirm-modal.scss
@@ -1,0 +1,59 @@
+@import '../../scss/variables';
+@import '../../scss/colors';
+@import '../../scss/mixins';
+@import '../../scss/atoms/button';
+
+@import '../comment/comment.scss';
+
+.confirm-modal {
+  @include z-level(3);
+  display: flex;
+  flex-flow: column;
+  justify-content: space-around;
+  position: fixed;
+  min-width: 20 * $baseline;
+  max-width: 400px;
+  min-height: 2 * $baseline;
+  max-height: 300px;
+  padding: 2 * $spacer;
+  border: solid $palette-light 1px;
+  border-radius: $border-radius-default;
+  background-color: $palette-lighter;
+  margin: 0 0 $baseline;
+  cursor: default;
+  &:focus {
+    outline: none;
+    box-shadow: 0 2px 10px $palette-shadow-default;
+  }
+  &.body {
+    text-align: center;
+  }
+  &.button-container {
+    display: flex;
+    flex-flow: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+}
+
+.confirm-button {
+  @include button();
+  margin: $baseline;
+  padding: $baseline $spacer;
+  background: $palette-accent;
+  color: $palette-lighter;
+}
+
+.confirm-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  @include z-level(2);
+  background-color: rgba(0, 0, 0, 0.1);
+}
+

--- a/client/src/components/reactions/reactions.scss
+++ b/client/src/components/reactions/reactions.scss
@@ -28,6 +28,10 @@ $reaction-border: 1px solid $palette-light;
   overflow: visible;
   transition: $transition-default-all;
   transition-property: box-shadow;
+
+  &:focus {
+    background-color: rgba($palette-light, 0.3);
+  }
 }
 
 .reaction:first-of-type {

--- a/client/src/components/submit-field/submit-field.js
+++ b/client/src/components/submit-field/submit-field.js
@@ -37,7 +37,7 @@ class SubmitField extends React.Component {
         <textarea
           value={this.state.value}
           onChange={this.handleChange}
-          placeholder="Write comment..."
+          placeholder={this.props.threadId ? 'Reply to thread...' : 'Write comment...'}
         />
         <input className={css('submit-comment')} type="submit" value="Comment" />
       </form>

--- a/client/src/components/submit-field/submit-field.js
+++ b/client/src/components/submit-field/submit-field.js
@@ -2,8 +2,9 @@ import React from 'react'
 
 // Helpers
 import classNames from 'classnames/bind'
-
-
+import * as DomTagging from '../../dom-tagging'
+// Components
+import TagElementButton from '../tag-element-button/tag-element-button'
 // Styles
 import submitFieldStyles from './submit-field.scss'
 
@@ -14,9 +15,14 @@ class SubmitField extends React.Component {
     super(props)
     this.state = {
       value: '',
+      taggingModeActive: false,
+      taggedElementXPath: '',
     }
     this.handleChange = this.handleChange.bind(this)
     this.passSubmit = this.passSubmit.bind(this)
+    this.toggleTagElementState = this.toggleTagElementState.bind(this)
+    this.handleElementTagged = this.handleElementTagged.bind(this)
+    this.unsetTaggedElement = this.unsetTaggedElement.bind(this)
   }
 
   handleChange(event) {
@@ -28,19 +34,49 @@ class SubmitField extends React.Component {
     event.nativeEvent.stopImmediatePropagation()
     this.setState({ value: '' })
 
-    this.props.handleSubmit(event, this.state.value, this.props.threadId)
+    this.props.handleSubmit(event,
+      this.state.taggedElementXPath,
+      this.state.value,
+      this.props.threadId)
+  }
+
+  toggleTagElementState() {
+    this.setState(prevState => ({ taggingModeActive: !prevState.taggingModeActive }))
+    this.props.toggleTagElementState()
+  }
+
+  handleElementTagged(event) {
+    const xPath = DomTagging.getXPathByElement(event)
+    this.setState({
+      taggedElementXPath: xPath,
+    })
+  }
+
+  unsetTaggedElement() {
+    this.setState({
+      taggedElementXPath: '',
+    })
   }
 
   render() {
+    const { value, taggingModeActive, taggedElementXPath } = this.state
     return (
       <form className={css('comment-form')} onSubmit={this.passSubmit}>
         <textarea
-          value={this.state.value}
+          value={value}
           onChange={this.handleChange}
           placeholder={this.props.threadId ? 'Reply to thread...' : 'Write comment...'}
           ref={this.props.inputRef}
         />
-        <input className={css('submit-comment')} type="submit" value="Comment" />
+        <div className={css('button-container')}>
+          <TagElementButton
+            active={taggingModeActive}
+            elementTagged={this.handleElementTagged}
+            toggleTagElementState={this.toggleTagElementState}
+            selected={taggedElementXPath !== ''}
+          />
+          <input className={css('submit-comment')} type="submit" value="Comment" />
+        </div>
       </form>
     )
   }

--- a/client/src/components/submit-field/submit-field.js
+++ b/client/src/components/submit-field/submit-field.js
@@ -38,6 +38,7 @@ class SubmitField extends React.Component {
           value={this.state.value}
           onChange={this.handleChange}
           placeholder={this.props.threadId ? 'Reply to thread...' : 'Write comment...'}
+          ref={this.props.inputRef}
         />
         <input className={css('submit-comment')} type="submit" value="Comment" />
       </form>

--- a/client/src/components/submit-field/submit-field.js
+++ b/client/src/components/submit-field/submit-field.js
@@ -1,0 +1,23 @@
+import React from 'react'
+
+// Helpers
+import classNames from 'classnames/bind'
+
+
+// Styles
+import submitFieldStyles from './submit-field.scss'
+
+const css = classNames.bind(submitFieldStyles)
+
+const SubmitField = ({ value, onChange, onSubmit }) => (
+  <form className={css('comment-form')} onSubmit={onSubmit}>
+    <textarea
+      value={value}
+      onChange={onChange}
+      placeholder="Write comment..."
+    />
+    <input className={css('submit-comment')} type="submit" value="Comment" />
+  </form>
+)
+
+export default SubmitField

--- a/client/src/components/submit-field/submit-field.js
+++ b/client/src/components/submit-field/submit-field.js
@@ -32,7 +32,10 @@ class SubmitField extends React.Component {
   passSubmit(event) {
     event.preventDefault()
     event.nativeEvent.stopImmediatePropagation()
-    this.setState({ value: '' })
+    this.setState({
+      value: '',
+      taggedElementXPath: '',
+    })
 
     this.props.handleSubmit(event,
       this.state.taggedElementXPath,

--- a/client/src/components/submit-field/submit-field.js
+++ b/client/src/components/submit-field/submit-field.js
@@ -9,15 +9,40 @@ import submitFieldStyles from './submit-field.scss'
 
 const css = classNames.bind(submitFieldStyles)
 
-const SubmitField = ({ value, onChange, onSubmit }) => (
-  <form className={css('comment-form')} onSubmit={onSubmit}>
-    <textarea
-      value={value}
-      onChange={onChange}
-      placeholder="Write comment..."
-    />
-    <input className={css('submit-comment')} type="submit" value="Comment" />
-  </form>
-)
+class SubmitField extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      value: '',
+    }
+    this.handleChange = this.handleChange.bind(this)
+    this.passSubmit = this.passSubmit.bind(this)
+  }
+
+  handleChange(event) {
+    this.setState({ value: event.target.value })
+  }
+
+  passSubmit(event) {
+    event.preventDefault()
+    event.nativeEvent.stopImmediatePropagation()
+    this.setState({ value: '' })
+
+    this.props.handleSubmit(event, this.state.value, this.props.threadId)
+  }
+
+  render() {
+    return (
+      <form className={css('comment-form')} onSubmit={this.passSubmit}>
+        <textarea
+          value={this.state.value}
+          onChange={this.handleChange}
+          placeholder="Write comment..."
+        />
+        <input className={css('submit-comment')} type="submit" value="Comment" />
+      </form>
+    )
+  }
+}
 
 export default SubmitField

--- a/client/src/components/submit-field/submit-field.scss
+++ b/client/src/components/submit-field/submit-field.scss
@@ -5,8 +5,7 @@
 
 @import '../survey-panel/survey-panel.scss';
 @import '../comment/comment.scss';
-
-$panel-min-width: 300px;
+@import '../comment-panel/comment-panel.scss';
 
 .comment-form {
   display: flex;
@@ -19,9 +18,10 @@ $panel-min-width: 300px;
   textarea {
     @extend .comment;
     display: block;
-    max-width: 100%;
     min-width: 100%;
+    max-width: 100%;
     min-height: 3em;
+    max-height: $panel-min-width;
     border: none;
 
     &:focus {

--- a/client/src/components/submit-field/submit-field.scss
+++ b/client/src/components/submit-field/submit-field.scss
@@ -1,0 +1,41 @@
+@import '../../scss/variables';
+@import '../../scss/colors';
+@import '../../scss/mixins';
+@import '../../scss/atoms/button';
+
+@import '../survey-panel/survey-panel.scss';
+@import '../comment/comment.scss';
+
+$panel-min-width: 300px;
+
+.comment-form {
+  display: flex;
+  flex-flow: column;
+  flex-shrink: 0;
+  flex-grow: 0;
+  justify-content: center;
+  margin-top: $baseline;
+
+  textarea {
+    @extend .comment;
+    display: block;
+    max-width: 100%;
+    min-width: $panel-min-width;
+    min-height: 3em;
+    border: none;
+
+    &:focus {
+      outline: none;
+      box-shadow: 0 2px 10px $palette-shadow-default;
+    }
+  }
+
+  .submit-comment {
+    @include button();
+    align-self: flex-end;
+    margin-top: $baseline;
+    padding: $baseline $spacer;
+    background: $palette-accent;
+    color: $palette-lighter;
+  }
+}

--- a/client/src/components/submit-field/submit-field.scss
+++ b/client/src/components/submit-field/submit-field.scss
@@ -30,10 +30,19 @@
     }
   }
 
+  .button-container {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+    flex-shrink: 0;
+    flex-grow: 0;
+  }
+
   .submit-comment {
     @include button();
     align-self: flex-end;
     margin-top: $baseline;
+    margin-left: $baseline;
     padding: $baseline $spacer;
     background: $palette-accent;
     color: $palette-lighter;

--- a/client/src/components/submit-field/submit-field.scss
+++ b/client/src/components/submit-field/submit-field.scss
@@ -33,15 +33,15 @@
   .button-container {
     align-items: center;
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     flex-shrink: 0;
     flex-grow: 0;
+    margin-top: $baseline;
   }
 
   .submit-comment {
     @include button();
     align-self: flex-end;
-    margin-top: $baseline;
     margin-left: $baseline;
     padding: $baseline $spacer;
     background: $palette-accent;

--- a/client/src/components/submit-field/submit-field.scss
+++ b/client/src/components/submit-field/submit-field.scss
@@ -20,7 +20,7 @@ $panel-min-width: 300px;
     @extend .comment;
     display: block;
     max-width: 100%;
-    min-width: $panel-min-width;
+    min-width: 100%;
     min-height: 3em;
     border: none;
 

--- a/client/src/components/tag-element-button/tag-element-button.js
+++ b/client/src/components/tag-element-button/tag-element-button.js
@@ -1,5 +1,4 @@
 import React from 'react'
-
 // Helpers
 import classNames from 'classnames/bind'
 import InlineSVG from 'svg-inline-react'
@@ -46,7 +45,7 @@ class TagElementButton extends React.Component {
         className={css('button', { active }, { selected })}
         onClick={DomTagging.toggleMarkingMode}
       >
-        {active ? 'Cancel' : <InlineSVG src={TargetIcon} />}
+        {active ? 'Cancel' : <InlineSVG src={TargetIcon} raw />}
       </button>
     )
   }

--- a/client/src/components/tag-element-button/tag-element-button.js
+++ b/client/src/components/tag-element-button/tag-element-button.js
@@ -42,7 +42,7 @@ class TagElementButton extends React.Component {
     return (
       <button
         type="button"
-        className={css('button', { active }, { selected })}
+        className={css('button', { active, selected })}
         onClick={() => {
           DomTagging.setElementTaggedCallback(event => elementTagged(event))
           DomTagging.setToggleTagElementStateCallback(() => toggleTagElementState())

--- a/client/src/components/tag-element-button/tag-element-button.js
+++ b/client/src/components/tag-element-button/tag-element-button.js
@@ -37,13 +37,17 @@ class TagElementButton extends React.Component {
   }
 
   render() {
-    const { active, selected } = this.props
+    const { active, selected, elementTagged, toggleTagElementState } = this.props
 
     return (
       <button
         type="button"
         className={css('button', { active }, { selected })}
-        onClick={DomTagging.toggleMarkingMode}
+        onClick={() => {
+          DomTagging.setElementTaggedCallback(event => elementTagged(event))
+          DomTagging.setToggleTagElementStateCallback(() => toggleTagElementState())
+          DomTagging.toggleMarkingMode()
+        }}
       >
         {active ? 'Cancel' : <InlineSVG src={TargetIcon} raw />}
       </button>

--- a/client/src/components/tag-element-button/tag-element-button.js
+++ b/client/src/components/tag-element-button/tag-element-button.js
@@ -1,6 +1,11 @@
 import React from 'react'
+
+// Helpers
 import classNames from 'classnames/bind'
+import InlineSVG from 'svg-inline-react'
 import * as DomTagging from '../../dom-tagging'
+// Assets
+import TargetIcon from '../../assets/svg/baseline-location_searching-24px.svg'
 // Styles
 import styles from './tag-element-button.scss'
 
@@ -33,15 +38,15 @@ class TagElementButton extends React.Component {
   }
 
   render() {
-    const { active } = this.props
+    const { active, selected } = this.props
 
     return (
       <button
         type="button"
-        className={css('button', { active })}
+        className={css('button', { active }, { selected })}
         onClick={DomTagging.toggleMarkingMode}
       >
-        {active ? 'Cancel' : 'Tag'}
+        {active ? 'Cancel' : <InlineSVG src={TargetIcon} />}
       </button>
     )
   }

--- a/client/src/components/tag-element-button/tag-element-button.scss
+++ b/client/src/components/tag-element-button/tag-element-button.scss
@@ -4,21 +4,48 @@
 @import '../../scss/atoms/button';
 
 .button {
-  @include button(2px);
-  @include display-and-animate();
-  position: fixed;
-  bottom: 12%;
-  left: 3%;
-  $dimension: 30px;
-  height: $dimension;
-  padding: $baseline $spacer;
-  box-shadow: 0 3px 5px $palette-light;
-  color: $palette-lighter;
-  background: $palette-accent;
+  @include button(100%);
+  cursor: pointer;
+  margin-top: $spacer;
+  padding: $baseline;
+  box-shadow: 0 2px 5px $palette-medium;
+  background: $palette-white;
   &.active {
-    background: $palette-dark;
-    &, & * {
-      visibility: visible;
+    visibility: visible;
+    @include button(2px);
+    color: $palette-dark;
+    background: $palette-accent;
+    box-shadow: 0 3px 5px $palette-light;
+
+  }
+  &.selected {
+    background: $palette-medium;
+  }
+  i {
+    display: block;
+    width: $icon-dimension-default;
+    height: $icon-dimension-default;
+    margin-left: auto;
+    margin-right: auto;
+    svg {
+      $target-icon-dimension: $icon-dimension-default;
+      width: $target-icon-dimension;
+      height: $target-icon-dimension;
+      margin-left: auto;
+      margin-right: auto;
+      fill: $palette-dark;
+      transition: fill $transition-default-tail
+    }
+
+    &:hover svg {
+      fill: $palette-black;
+      transition: fill $transition-default-tail
+    }
+
+    &:focus svg {
+      fill: $palette-accent;
+      transition: fill $transition-default-tail
     }
   }
 }
+

--- a/client/src/components/tag-element-button/tag-element-button.scss
+++ b/client/src/components/tag-element-button/tag-element-button.scss
@@ -3,48 +3,29 @@
 @import '../../scss/mixins';
 @import '../../scss/atoms/button';
 
+@import '../comment/comment';
+
 .button {
-  @include button(100%);
-  cursor: pointer;
-  margin-top: $spacer;
+  @extend %target-icon;
+  @include shadow-outline();
   padding: $baseline;
-  box-shadow: 0 2px 5px $palette-medium;
+  border-radius: 100%;
   background: $palette-white;
+  cursor: pointer;
+
   &.active {
-    visibility: visible;
     @include button(2px);
-    color: $palette-dark;
-    background: $palette-accent;
+    visibility: visible;
     box-shadow: 0 3px 5px $palette-light;
-
+    background: $palette-accent;
+    color: $palette-white;
   }
+
   &.selected {
-    background: $palette-medium;
-  }
-  i {
-    display: block;
-    width: $icon-dimension-default;
-    height: $icon-dimension-default;
-    margin-left: auto;
-    margin-right: auto;
+    background: $palette-accent;
+
     svg {
-      $target-icon-dimension: $icon-dimension-default;
-      width: $target-icon-dimension;
-      height: $target-icon-dimension;
-      margin-left: auto;
-      margin-right: auto;
-      fill: $palette-dark;
-      transition: fill $transition-default-tail
-    }
-
-    &:hover svg {
-      fill: $palette-black;
-      transition: fill $transition-default-tail
-    }
-
-    &:focus svg {
-      fill: $palette-accent;
-      transition: fill $transition-default-tail
+      fill: $palette-white;
     }
   }
 }

--- a/client/src/components/tag-element-button/tag-element-button.scss
+++ b/client/src/components/tag-element-button/tag-element-button.scss
@@ -11,12 +11,14 @@
   padding: $baseline;
   border-radius: 100%;
   background: $palette-white;
+  color: transparent;
   cursor: pointer;
 
   &.active {
     @include button(2px);
     visibility: visible;
     box-shadow: 0 3px 5px $palette-light;
+    padding: $baseline $spacer;
     background: $palette-accent;
     color: $palette-white;
   }

--- a/client/src/components/tag-element-button/tag-element-button.scss
+++ b/client/src/components/tag-element-button/tag-element-button.scss
@@ -17,7 +17,7 @@
   &.active {
     @include button(2px);
     visibility: visible;
-    box-shadow: 0 3px 5px $palette-light;
+    box-shadow: 0 2px 5px $palette-medium;
     padding: $baseline $spacer;
     background: $palette-accent;
     color: $palette-white;

--- a/client/src/components/thread/thread.js
+++ b/client/src/components/thread/thread.js
@@ -65,7 +65,7 @@ class Thread extends React.Component {
 
   canDelete(commentUserId) {
     const [currentUser] = Object.keys(this.props.users)
-    return currentUser === commentUserId
+    return currentUser === commentUserId || this.props.role === 'dev'
   }
 
   render() {

--- a/client/src/components/thread/thread.js
+++ b/client/src/components/thread/thread.js
@@ -17,8 +17,13 @@ class Thread extends React.Component {
       buttonText: this.props.comments.length > 1 ? 'Expand' : 'Reply',
     }
 
+    this.handleChange = this.handleChange.bind(this)
     this.handleClick = this.handleClick.bind(this)
     this.expandedThread = this.expandedThread.bind(this)
+  }
+
+  handleChange(event) {
+    this.props.onChange(this.props.id, event)
   }
 
   handleClick() {
@@ -38,8 +43,9 @@ class Thread extends React.Component {
           comment => <Comment key={comment.id} comment={comment} id={comment.id} />,
         )}
         <SubmitField
+          value={this.props.value}
           onSubmit={this.props.onSubmit}
-          onChange={this.props.onChange}
+          onChange={this.handleChange}
         />
       </>
     )

--- a/client/src/components/thread/thread.js
+++ b/client/src/components/thread/thread.js
@@ -15,7 +15,9 @@ class Thread extends React.Component {
     super(props)
 
     this.handleClick = this.handleClick.bind(this)
+    this.buttonText = this.buttonText.bind(this)
     this.expandedThread = this.expandedThread.bind(this)
+    this.replyField = React.createRef()
   }
 
   handleClick() {
@@ -44,12 +46,15 @@ class Thread extends React.Component {
               id={comment.id}
               role={this.props.role}
               op={op}
+              onClick={() => this.replyField.current.focus()}
+              buttonText="Reply"
             />
           ),
         )}
         <SubmitField
           handleSubmit={this.props.handleSubmit}
           threadId={this.props.id}
+          inputRef={this.replyField}
         />
       </>
     )
@@ -66,17 +71,11 @@ class Thread extends React.Component {
           comment={firstComment}
           id={firstComment.id}
           role={role}
+          onClick={this.handleClick}
+          buttonText={this.buttonText()}
         />
-        <div className={css('expand-button-container')}>
-          <button
-            type="button"
-            onClick={this.handleClick}
-          >
-            { this.buttonText() }
-          </button>
-        </div>
         <aside className={css('sub-thread')}>
-          { this.expandedThread(firstComment.userId) }
+          {this.expandedThread(firstComment.userId)}
         </aside>
       </div>
     )

--- a/client/src/components/thread/thread.js
+++ b/client/src/components/thread/thread.js
@@ -17,6 +17,7 @@ class Thread extends React.Component {
     this.handleClick = this.handleClick.bind(this)
     this.buttonText = this.buttonText.bind(this)
     this.expandedThread = this.expandedThread.bind(this)
+    this.canDelete = this.canDelete.bind(this)
     this.replyField = React.createRef()
   }
 
@@ -48,6 +49,8 @@ class Thread extends React.Component {
               op={op}
               onClick={() => this.replyField.current.focus()}
               buttonText="Reply"
+              canDelete={this.canDelete(comment.userId)}
+              deleteComment={this.props.deleteComment}
             />
           ),
         )}
@@ -58,6 +61,11 @@ class Thread extends React.Component {
         />
       </>
     )
+  }
+
+  canDelete(commentUserId) {
+    const [currentUser] = Object.keys(this.props.users)
+    return currentUser === commentUserId
   }
 
   render() {
@@ -73,6 +81,8 @@ class Thread extends React.Component {
           role={role}
           onClick={this.handleClick}
           buttonText={this.buttonText()}
+          canDelete={this.canDelete(firstComment.userId)}
+          deleteComment={this.props.deleteComment}
         />
         <aside className={css('sub-thread')}>
           {this.expandedThread(firstComment.userId)}

--- a/client/src/components/thread/thread.js
+++ b/client/src/components/thread/thread.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import * as R from 'ramda'
 
 import classNames from 'classnames/bind'
 
@@ -15,20 +14,40 @@ class Thread extends React.Component {
     super(props)
     this.state = {
       isExpanded: false,
-      buttonText: 'Reply',
+      buttonText: this.props.comments.length > 1 ? 'Expand' : 'Reply',
     }
 
     this.handleClick = this.handleClick.bind(this)
+    this.expandedThread = this.expandedThread.bind(this)
   }
 
   handleClick() {
-    this.setState(prevState => ({ isExpanded: !prevState.isExpanded }))
-    console.log('Exnpanding thread is expanded: ', this.state.isExpanded)
+    this.setState(prevState => ({
+      isExpanded: !prevState.isExpanded,
+      buttonText: prevState.isExpanded ? 'Reply' : 'Collapse',
+    }))
+    console.log('Expanding thread is expanded: ', this.state.isExpanded)
+  }
+
+  expandedThread() {
+    if (!this.state.isExpanded) { return }
+    const threadComments = this.props.comments.slice(1)
+    return (
+      <>
+        {threadComments.map(
+          comment => <Comment key={comment.id} comment={comment} id={comment.id} />,
+        )}
+        <SubmitField
+          onSubmit={this.props.onSubmit}
+          onChange={this.props.onChange}
+        />
+      </>
+    )
   }
 
   render() {
     const comment = this.props.comments[0]
-    const { buttonText, isExpanded } = this.state
+    const { buttonText } = this.state
     return (
       <div className={css('thread')}>
         <Comment key={comment.id} comment={comment} id={comment.id} />
@@ -39,19 +58,11 @@ class Thread extends React.Component {
         >
           { buttonText }
         </button>
-        {isExpanded ? <SubmitField /> : null}
+        { this.expandedThread() }
       </div>
     )
   }
 }
-
-/* threadContainer() {
-  if (R.isEmpty(this.props.comments)) return (<p>No comments fetched.</p>)
-  const threads = new Set(Object.values(this.props.comments).map(comment => comment.threadId)))
-  const threadGroups = R.groupBy((arr) => {
-
-  })
-} */
 
 export default Thread
 

--- a/client/src/components/thread/thread.js
+++ b/client/src/components/thread/thread.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import * as R from 'ramda'
 
 import classNames from 'classnames/bind'
 
@@ -13,14 +14,8 @@ class Thread extends React.Component {
   constructor(props) {
     super(props)
 
-    this.handleChange = this.handleChange.bind(this)
     this.handleClick = this.handleClick.bind(this)
     this.expandedThread = this.expandedThread.bind(this)
-  }
-
-  handleChange(event) {
-    this.props.onChange(event)
-    this.props.updateCurrentThread(this.props.id)
   }
 
   handleClick() {
@@ -37,22 +32,24 @@ class Thread extends React.Component {
   expandedThread() {
     if (this.props.currentThread !== this.props.id) { return }
     const threadComments = this.props.comments.slice(1)
+    const sortByTime = R.sortBy(comment => comment.time)
+    const sortedComments = sortByTime(threadComments)
     return (
       <>
-        {threadComments.map(
+        {sortedComments.map(
           comment => <Comment key={comment.id} comment={comment} id={comment.id} />,
         )}
         <SubmitField
-          value={this.props.value}
-          onSubmit={this.props.onSubmit}
-          onChange={this.handleChange}
+          handleSubmit={this.props.handleSubmit}
+          threadId={this.props.id}
         />
       </>
     )
   }
 
   render() {
-    const comment = this.props.comments[0]
+    const sortByTime = R.sortBy(comment => comment.time)
+    const comment = sortByTime(this.props.comments)[0]
     return (
       <div className={css('thread')}>
         <Comment key={comment.id} comment={comment} id={comment.id} />

--- a/client/src/components/thread/thread.js
+++ b/client/src/components/thread/thread.js
@@ -27,7 +27,11 @@ class Thread extends React.Component {
   }
 
   buttonText() {
-    const openText = this.props.comments.length > 1 ? 'Expand' : 'Reply'
+    let openText = 'Reply'
+    const replyAmount = this.props.comments.length - 1
+    if (replyAmount > 0) {
+      openText = `Show ${replyAmount} Repl${replyAmount === 1 ? 'y' : 'ies'}`
+    }
     const isOpen = this.props.currentThread !== this.props.id
     return isOpen ? openText : 'Collapse'
   }
@@ -71,8 +75,8 @@ class Thread extends React.Component {
   }
 
   canDelete(commentUserId) {
-    const [currentUser] = Object.keys(this.props.users)
-    return currentUser === commentUserId || this.props.role === 'dev'
+    const { users } = this.props
+    return users.hasOwnProperty(commentUserId) || this.props.role === 'dev'
   }
 
   render() {

--- a/client/src/components/thread/thread.js
+++ b/client/src/components/thread/thread.js
@@ -57,14 +57,17 @@ class Thread extends React.Component {
     return (
       <div className={css('thread')}>
         <Comment key={comment.id} comment={comment} id={comment.id} />
-        <button
-          className={css('show-thread')}
-          type="button"
-          onClick={this.handleClick}
-        >
-          { buttonText }
-        </button>
-        { this.expandedThread() }
+        <div className={css('expand-button-container')}>
+          <button
+            type="button"
+            onClick={this.handleClick}
+          >
+            { buttonText }
+          </button>
+        </div>
+        <aside className={css('sub-thread')}>
+          { this.expandedThread() }
+        </aside>
       </div>
     )
   }

--- a/client/src/components/thread/thread.js
+++ b/client/src/components/thread/thread.js
@@ -4,6 +4,7 @@ import * as R from 'ramda'
 import classNames from 'classnames/bind'
 
 import Comment from '../comment/comment'
+import SubmitField from '../submit-field/submit-field'
 
 import styles from './thread.scss'
 
@@ -14,16 +15,32 @@ class Thread extends React.Component {
     super(props)
     this.state = {
       isExpanded: false,
+      buttonText: 'Reply',
     }
+
+    this.handleClick = this.handleClick.bind(this)
   }
 
+  handleClick() {
+    this.setState(prevState => ({ isExpanded: !prevState.isExpanded }))
+    console.log('Exnpanding thread is expanded: ', this.state.isExpanded)
+  }
 
   render() {
-    const { isExpanded } = this.state
-    console.log(isExpanded)
     const comment = this.props.comments[0]
+    const { buttonText, isExpanded } = this.state
     return (
-      <Comment key={comment.id} comment={comment} id={comment.id} />
+      <div className={css('thread')}>
+        <Comment key={comment.id} comment={comment} id={comment.id} />
+        <button
+          className={css('show-thread')}
+          type="button"
+          onClick={this.handleClick}
+        >
+          { buttonText }
+        </button>
+        {isExpanded ? <SubmitField /> : null}
+      </div>
     )
   }
 }

--- a/client/src/components/thread/thread.js
+++ b/client/src/components/thread/thread.js
@@ -27,11 +27,11 @@ class Thread extends React.Component {
   }
 
   handleClick() {
+    const openText = this.props.comments.length > 1 ? 'Expand' : 'Reply'
     this.setState(prevState => ({
       isExpanded: !prevState.isExpanded,
-      buttonText: prevState.isExpanded ? 'Reply' : 'Collapse',
+      buttonText: prevState.isExpanded ? openText : 'Collapse',
     }))
-    console.log('Expanding thread is expanded: ', this.state.isExpanded)
   }
 
   expandedThread() {

--- a/client/src/components/thread/thread.js
+++ b/client/src/components/thread/thread.js
@@ -58,6 +58,7 @@ class Thread extends React.Component {
           handleSubmit={this.props.handleSubmit}
           threadId={this.props.id}
           inputRef={this.replyField}
+          toggleTagElementState={this.props.toggleTagElementState}
         />
       </>
     )

--- a/client/src/components/thread/thread.js
+++ b/client/src/components/thread/thread.js
@@ -12,10 +12,6 @@ const css = classNames.bind(styles)
 class Thread extends React.Component {
   constructor(props) {
     super(props)
-    this.state = {
-      isExpanded: false,
-      buttonText: this.props.comments.length > 1 ? 'Expand' : 'Reply',
-    }
 
     this.handleChange = this.handleChange.bind(this)
     this.handleClick = this.handleClick.bind(this)
@@ -23,19 +19,23 @@ class Thread extends React.Component {
   }
 
   handleChange(event) {
-    this.props.onChange(this.props.id, event)
+    this.props.onChange(event)
+    this.props.updateCurrentThread(this.props.id)
   }
 
   handleClick() {
+    const isOpen = (this.props.currentThread === this.props.id)
+    this.props.updateCurrentThread(isOpen ? '' : this.props.id)
+  }
+
+  buttonText() {
     const openText = this.props.comments.length > 1 ? 'Expand' : 'Reply'
-    this.setState(prevState => ({
-      isExpanded: !prevState.isExpanded,
-      buttonText: prevState.isExpanded ? openText : 'Collapse',
-    }))
+    const isOpen = this.props.currentThread !== this.props.id
+    return isOpen ? openText : 'Collapse'
   }
 
   expandedThread() {
-    if (!this.state.isExpanded) { return }
+    if (this.props.currentThread !== this.props.id) { return }
     const threadComments = this.props.comments.slice(1)
     return (
       <>
@@ -53,7 +53,6 @@ class Thread extends React.Component {
 
   render() {
     const comment = this.props.comments[0]
-    const { buttonText } = this.state
     return (
       <div className={css('thread')}>
         <Comment key={comment.id} comment={comment} id={comment.id} />
@@ -62,7 +61,7 @@ class Thread extends React.Component {
             type="button"
             onClick={this.handleClick}
           >
-            { buttonText }
+            { this.buttonText() }
           </button>
         </div>
         <aside className={css('sub-thread')}>

--- a/client/src/components/thread/thread.js
+++ b/client/src/components/thread/thread.js
@@ -23,7 +23,7 @@ class Thread extends React.Component {
     console.log(isExpanded)
     const comment = this.props.comments[0]
     return (
-      <Comment key={comment.id} comment={comment} />
+      <Comment key={comment.id} comment={comment} id={comment.id} />
     )
   }
 }

--- a/client/src/components/thread/thread.js
+++ b/client/src/components/thread/thread.js
@@ -29,7 +29,7 @@ class Thread extends React.Component {
     return isOpen ? openText : 'Collapse'
   }
 
-  expandedThread() {
+  expandedThread(op) {
     if (this.props.currentThread !== this.props.id) { return }
     const threadComments = this.props.comments.slice(1)
     const sortByTime = R.sortBy(comment => comment.time)
@@ -37,7 +37,15 @@ class Thread extends React.Component {
     return (
       <>
         {sortedComments.map(
-          comment => <Comment key={comment.id} comment={comment} id={comment.id} />,
+          comment => (
+            <Comment
+              key={comment.id}
+              comment={comment}
+              id={comment.id}
+              role={this.props.role}
+              op={op}
+            />
+          ),
         )}
         <SubmitField
           handleSubmit={this.props.handleSubmit}
@@ -48,11 +56,17 @@ class Thread extends React.Component {
   }
 
   render() {
+    const { role } = this.props
     const sortByTime = R.sortBy(comment => comment.time)
-    const comment = sortByTime(this.props.comments)[0]
+    const firstComment = sortByTime(this.props.comments)[0]
     return (
       <div className={css('thread')}>
-        <Comment key={comment.id} comment={comment} id={comment.id} />
+        <Comment
+          key={firstComment.id}
+          comment={firstComment}
+          id={firstComment.id}
+          role={role}
+        />
         <div className={css('expand-button-container')}>
           <button
             type="button"
@@ -62,7 +76,7 @@ class Thread extends React.Component {
           </button>
         </div>
         <aside className={css('sub-thread')}>
-          { this.expandedThread() }
+          { this.expandedThread(firstComment.userId) }
         </aside>
       </div>
     )

--- a/client/src/components/thread/thread.js
+++ b/client/src/components/thread/thread.js
@@ -1,0 +1,40 @@
+import React from 'react'
+import * as R from 'ramda'
+
+import classNames from 'classnames/bind'
+
+import Comment from '../comment/comment'
+
+import styles from './thread.scss'
+
+const css = classNames.bind(styles)
+
+class Thread extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      isExpanded: false,
+    }
+  }
+
+
+  render() {
+    const { isExpanded } = this.state
+    console.log(isExpanded)
+    const comment = this.props.comments[0]
+    return (
+      <Comment key={comment.id} comment={comment} />
+    )
+  }
+}
+
+/* threadContainer() {
+  if (R.isEmpty(this.props.comments)) return (<p>No comments fetched.</p>)
+  const threads = new Set(Object.values(this.props.comments).map(comment => comment.threadId)))
+  const threadGroups = R.groupBy((arr) => {
+
+  })
+} */
+
+export default Thread
+

--- a/client/src/components/thread/thread.js
+++ b/client/src/components/thread/thread.js
@@ -32,28 +32,34 @@ class Thread extends React.Component {
     return isOpen ? openText : 'Collapse'
   }
 
+  threadIsExpanded() {
+    return this.props.currentThread !== this.props.id
+  }
+
   expandedThread(op) {
-    if (this.props.currentThread !== this.props.id) { return }
+    if (this.threadIsExpanded()) { return }
     const threadComments = this.props.comments.slice(1)
     const sortByTime = R.sortBy(comment => comment.time)
     const sortedComments = sortByTime(threadComments)
     return (
       <>
-        {sortedComments.map(
-          comment => (
-            <Comment
-              key={comment.id}
-              comment={comment}
-              id={comment.id}
-              role={this.props.role}
-              op={op}
-              onClick={() => this.replyField.current.focus()}
-              buttonText="Reply"
-              canDelete={this.canDelete(comment.userId)}
-              deleteComment={this.props.deleteComment}
-            />
-          ),
-        )}
+        {
+          sortedComments.map(
+            comment => (
+              <Comment
+                key={comment.id}
+                comment={comment}
+                id={comment.id}
+                role={this.props.role}
+                op={op}
+                onClick={() => this.replyField.current.focus()}
+                buttonText="Reply"
+                canDelete={this.canDelete(comment.userId)}
+                deleteComment={this.props.deleteComment}
+              />
+            ),
+          )
+        }
         <SubmitField
           handleSubmit={this.props.handleSubmit}
           threadId={this.props.id}
@@ -85,7 +91,7 @@ class Thread extends React.Component {
           canDelete={this.canDelete(firstComment.userId)}
           deleteComment={this.props.deleteComment}
         />
-        <aside className={css('sub-thread')}>
+        <aside className={css('sub-thread', { 'expanded-thread': this.threadIsExpanded() })}>
           {this.expandedThread(firstComment.userId)}
         </aside>
       </div>

--- a/client/src/components/thread/thread.scss
+++ b/client/src/components/thread/thread.scss
@@ -3,21 +3,28 @@
 @import '../../scss/mixins';
 @import '../../scss/atoms/button';
 
-.thread {
-  .comment {
-    width: 80%;
-    &:first-of-type {
-      width: 100%;
-    }
+.sub-thread {
+  margin-bottom: $spacer;
+  > * {
+    margin-left: $spacer;
+    width: calc(100% - #{$spacer});
   }
 
-  .comment-form {
-    width: 80%;
-    color: $palette-dark;
+  > div:first-of-type {
+    margin-top: -$spacer;
   }
 }
 
-.show-thread {
-  @include button();
-  margin: -20 * $spacer auto;
+.expand-button-container {
+  display: flex;
+  justify-content: flex-end;
+
+  button {
+    @include button();
+    background: white;
+    @include shadow-outline(1px);
+    position: relative;
+    top: -$baseline;
+    margin-right: $spacer;
+  }
 }

--- a/client/src/components/thread/thread.scss
+++ b/client/src/components/thread/thread.scss
@@ -11,7 +11,7 @@
   }
 
   > *:first-of-type {
-    margin-top: -$spacer;
+    margin-top: $spacer;
   }
 
   > div:first-of-type ~ form {
@@ -19,16 +19,3 @@
   }
 }
 
-.expand-button-container {
-  display: flex;
-  justify-content: flex-end;
-
-  button {
-    @include button();
-    background: white;
-    @include shadow-outline(1px);
-    position: relative;
-    top: -$baseline;
-    margin-right: $spacer;
-  }
-}

--- a/client/src/components/thread/thread.scss
+++ b/client/src/components/thread/thread.scss
@@ -10,10 +10,14 @@
       width: 100%;
     }
   }
+
+  .comment-form {
+    width: 80%;
+    color: $palette-dark;
+  }
 }
 
 .show-thread {
   @include button();
-  @include z-level(9)
-  margin: -$spacer auto;
+  margin: -20 * $spacer auto;
 }

--- a/client/src/components/thread/thread.scss
+++ b/client/src/components/thread/thread.scss
@@ -1,0 +1,19 @@
+@import '../../scss/variables';
+@import '../../scss/colors';
+@import '../../scss/mixins';
+@import '../../scss/atoms/button';
+
+.thread {
+  .comment {
+    width: 80%;
+    &:first-of-type {
+      width: 100%;
+    }
+  }
+}
+
+.show-thread {
+  @include button();
+  @include z-level(9)
+  margin: -$spacer auto;
+}

--- a/client/src/components/thread/thread.scss
+++ b/client/src/components/thread/thread.scss
@@ -5,6 +5,7 @@
 
 .sub-thread {
   margin-bottom: $spacer;
+
   > * {
     margin-left: $spacer;
     width: calc(100% - #{$spacer});

--- a/client/src/components/thread/thread.scss
+++ b/client/src/components/thread/thread.scss
@@ -10,8 +10,12 @@
     width: calc(100% - #{$spacer});
   }
 
-  > div:first-of-type {
+  > *:first-of-type {
     margin-top: -$spacer;
+  }
+
+  > div:first-of-type ~ form {
+    margin-top: $spacer;
   }
 }
 

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -15,7 +15,6 @@ import { prepareReactRoot } from './shadowDomHelper'
 import OpenSurveyPanelButton from './components/open-survey-panel-button/open-survey-panel-button'
 import SurveyPanel from './components/survey-panel/survey-panel'
 import CommentPanel from './components/comment-panel/comment-panel'
-import TagElementButton from './components/tag-element-button/tag-element-button'
 // Internal js
 import { setupPersist } from './persist'
 import { loadPersistData, setPersistData, loadComments, updateRole } from './actions'
@@ -129,11 +128,6 @@ class MainView extends React.Component {
       <div
         className={css('feedback-app-container', { 'tagging-mode-active': taggingModeActive })}
       >
-        <TagElementButton
-          active={taggingModeActive}
-          elementTagged={this.handleElementTagged}
-          toggleTagElementState={this.toggleTagElementState}
-        />
         <OpenSurveyPanelButton
           hidden={surveyButtonIsHidden}
           onClick={this.handleSurveyPanelClick}
@@ -145,6 +139,7 @@ class MainView extends React.Component {
         <CommentPanel
           taggedElementXPath={this.state.taggedElementXPath}
           unsetTaggedElement={this.unsetTaggedElement}
+          toggleTagElementState={this.toggleTagElementState}
         />
       </div>
     )

--- a/client/src/scss/_colors.scss
+++ b/client/src/scss/_colors.scss
@@ -1,11 +1,14 @@
 $palette-white: white;
 $palette-lighter: #fdfdfd;
+$palette-light-medium: #d8d8d8;
 $palette-light: #d8d8d8;
 $palette-medium: #b7b8ba;
 $palette-dark: #444444;
 $palette-darker: #222222;
 $palette-black: black;
 $palette-accent: #00bfc9;
+
+$palette-badge-background: #eeeeee;
 
 $palette-shadow-default: rgba($palette-medium, 0.8);
 $palette-shadow-light: rgba($palette-light, 9);

--- a/docs/api.md
+++ b/docs/api.md
@@ -94,6 +94,20 @@ comments can be linked to a thread with
 ```
 
 Returns `{ id, threadId }` of the new comment
+### [DELETE /api/comments](../server/src/routes/comments.js#L130)
+
+Tries to delete a comment. Only successful if the userId of the comment is the same
+as the user trying to delete the comment, or if the user is a dev.
+
+Returns the numbers of rows affected,
+one if the comment was deleted and 0 if it was not successful.
+
+e.g.
+```json
+{
+  "delRows": 1
+}
+```
 
 ### [GET /api/comments/:threadId](../server/src/routes/comments.js#L110)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -100,7 +100,7 @@ comments can be linked to a thread with
 ```
 
 Returns `{ id, threadId }` of the new comment
-### [DELETE /api/comments](../server/src/routes/comments.js#L130)
+### [DELETE /api/comments](../server/src/routes/comments.js#L137)
 
 Tries to delete a comment. Only successful if the userId of the comment is the same
 as the user trying to delete the comment, or if the user is a dev.

--- a/server/src/api-tests/api-request.js
+++ b/server/src/api-tests/api-request.js
@@ -45,7 +45,7 @@ export default function apiRequest(method, path, body, optsArg) {
     da776df3: 'sf8a7s',
   }
 
-  const container = opts.container || 'one'
+  const container = opts.container || 'test'
 
   const authToken = btoa(JSON.stringify(users))
 

--- a/server/src/database.js
+++ b/server/src/database.js
@@ -49,7 +49,11 @@ export async function addReaction({
 
 export async function deleteReaction({
   emoji, userId, commentId,
-}) { return db.query('DELETE FROM reactions WHERE emoji=? AND user_id=? AND comment_id=?', [emoji, userId, commentId]) }
+}) { return db.del('DELETE FROM reactions WHERE emoji=? AND user_id=? AND comment_id=?', [emoji, userId, commentId]) }
+
+export async function deleteComment({
+  userId, commentId,
+}) { return db.del('DELETE FROM comments WHERE user_id=? AND id=?', [userId, commentId]) }
 
 export async function addComment({
   id, text, userId, threadId, blob,

--- a/server/src/database/database-postgres.js
+++ b/server/src/database/database-postgres.js
@@ -133,7 +133,6 @@ class PostgresDatabase {
    */
 
   async del(str, values) {
-    console.log(str, values)
     const preparedString = prepStatement(str)
     const res = await this.db.result(preparedString, values)
     return res.rowCount

--- a/server/src/database/database-postgres.js
+++ b/server/src/database/database-postgres.js
@@ -127,6 +127,16 @@ class PostgresDatabase {
     const preparedString = prepStatement(str)
     return this.db.multi(preparedString, values)
   }
+  /*
+  For using delete statements. Returns the number of rows affected.
+  Will return an empty array if DELETE was unsuccessful.
+   */
+
+  async del(str, values) {
+    const preparedString = prepStatement(str)
+    const res = await this.db.result(preparedString, values)
+    return res.rowCount
+  }
 }
 
 

--- a/server/src/database/database-postgres.js
+++ b/server/src/database/database-postgres.js
@@ -133,6 +133,7 @@ class PostgresDatabase {
    */
 
   async del(str, values) {
+    console.log(str, values)
     const preparedString = prepStatement(str)
     const res = await this.db.result(preparedString, values)
     return res.rowCount

--- a/server/src/database/database-sqlite.js
+++ b/server/src/database/database-sqlite.js
@@ -129,5 +129,22 @@ class SQLiteDatabase {
       })
     })
   }
+  /*
+  For using delete statements. Returns the number of rows affected.
+  Will return an empty array if DELETE was unsuccessful.
+   */
+
+  async del(...args) {
+    return new Promise((resolve, reject) => {
+      this.db.run(...args, function (err) {
+        if (err) {
+          verboseError(`DELERROR: ${err} on query ${args}`)
+          reject(err)
+        } else {
+          resolve(this.changes)
+        }
+      })
+    })
+  }
 }
 export default SQLiteDatabase

--- a/server/src/database/migrations/postgres/004-cascade-on-delete.sql
+++ b/server/src/database/migrations/postgres/004-cascade-on-delete.sql
@@ -1,0 +1,66 @@
+BEGIN TRANSACTION;
+
+ALTER TABLE comments
+DROP CONSTRAINT comments_thread_id_fkey;
+ALTER TABLE comments
+ADD CONSTRAINT comments_thread_id_fkey
+FOREIGN KEY (thread_id)
+REFERENCES threads(id)
+ON DELETE CASCADE;
+
+
+ALTER TABLE comments
+DROP CONSTRAINT comments_user_id_fkey;
+ALTER TABLE comments
+ADD CONSTRAINT comments_user_id_fkey
+FOREIGN KEY (user_id)
+REFERENCES users(id)
+ON DELETE CASCADE;
+
+
+ALTER TABLE questions
+DROP CONSTRAINT questions_thread_id_fkey;
+ALTER TABLE questions
+ADD CONSTRAINT questions_thread_id_fkey
+FOREIGN KEY (thread_id)
+REFERENCES threads(id)
+ON DELETE CASCADE;
+
+
+ALTER TABLE questions
+DROP CONSTRAINT questions_user_id_fkey;
+ALTER TABLE questions
+ADD CONSTRAINT questions_user_id_fkey
+FOREIGN KEY (user_id)
+REFERENCES users(id)
+ON DELETE CASCADE;
+
+
+ALTER TABLE reactions
+DROP CONSTRAINT reactions_user_id_fkey;
+ALTER TABLE reactions
+ADD CONSTRAINT reactions_user_id_fkey
+FOREIGN KEY (user_id)
+REFERENCES users(id)
+ON DELETE CASCADE;
+
+
+ALTER TABLE reactions
+DROP CONSTRAINT reactions_comment_id_fkey;
+ALTER TABLE reactions
+ADD CONSTRAINT reactions_comment_id_fkey
+FOREIGN KEY (comment_id)
+REFERENCES comments(id)
+ON DELETE CASCADE;
+
+
+ALTER TABLE threads
+DROP CONSTRAINT threads_container_id_fkey;
+ALTER TABLE threads
+ADD CONSTRAINT threads_container_id_fkey
+FOREIGN KEY (container_id)
+REFERENCES containers(id)
+ON DELETE CASCADE;
+
+
+COMMIT TRANSACTION;

--- a/server/src/database/migrations/sqlite/001-setup.sql
+++ b/server/src/database/migrations/sqlite/001-setup.sql
@@ -26,7 +26,7 @@ CREATE TABLE threads (
   id            CHAR(8) UNIQUE NOT NULL,
   container_id  CHAR(8) NOT NULL,
   blob          TEXT,
-  FOREIGN KEY (container_id) REFERENCES containers(id)
+  FOREIGN KEY (container_id) REFERENCES containers(id) ON DELETE CASCADE
 );
 
 -- Table: comments
@@ -37,8 +37,8 @@ CREATE TABLE comments (
     user_id   CHAR(8) NOT NULL,
     thread_id CHAR(8) NOT NULL,
     blob      TEXT,
-    FOREIGN KEY (user_id) REFERENCES users(id),
-    FOREIGN KEY (thread_id) REFERENCES threads(id)
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (thread_id) REFERENCES threads(id) ON DELETE CASCADE
 );
 
 -- Table: questions
@@ -47,10 +47,13 @@ CREATE TABLE questions (
     time      VARCHAR(30) DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
     text      TEXT NOT NULL,
     user_id   CHAR(8) NOT NULL,
-    thread_id VARCHAR(8) NOT NULL,
+    container_id VARCHAR(8) NOT NULL,
+    type      VARCHAR(16) NOT NULL,
     blob      TEXT,
-    FOREIGN KEY (user_id) REFERENCES users(id),
-    FOREIGN KEY (thread_id) REFERENCES threads(id)
+    order_id  INTEGER NOT NULL,
+
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (container_id) REFERENCES containers(id) ON DELETE CASCADE
 );
 
 -- Table: reactions
@@ -64,6 +67,19 @@ CREATE TABLE reactions (
     FOREIGN KEY (comment_id) REFERENCES comments(id),
 
     UNIQUE (emoji, user_id, comment_id) ON CONFLICT ROLLBACK
+);
+
+-- Table: answers
+CREATE TABLE answers (
+    id        CHAR(8) UNIQUE NOT NULL,
+    time      VARCHAR(30) DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+    user_id   CHAR(8) NOT NULL,
+    question_id CHAR(8) NOT NULL,
+    blob      TEXT,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (question_id) REFERENCES questions(id) ON DELETE CASCADE,
+
+    UNIQUE (user_id, question_id) ON CONFLICT ROLLBACK
 );
 
 

--- a/server/src/database/migrations/sqlite/001-setup.sql
+++ b/server/src/database/migrations/sqlite/001-setup.sql
@@ -47,13 +47,10 @@ CREATE TABLE questions (
     time      VARCHAR(30) DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
     text      TEXT NOT NULL,
     user_id   CHAR(8) NOT NULL,
-    container_id VARCHAR(8) NOT NULL,
-    type      VARCHAR(16) NOT NULL,
+    thread_id VARCHAR(8) NOT NULL,
     blob      TEXT,
-    order_id  INTEGER NOT NULL,
-
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
-    FOREIGN KEY (container_id) REFERENCES containers(id) ON DELETE CASCADE
+    FOREIGN KEY (thread_id) REFERENCES threads(id) ON DELETE CASCADE
 );
 
 -- Table: reactions
@@ -67,19 +64,6 @@ CREATE TABLE reactions (
     FOREIGN KEY (comment_id) REFERENCES comments(id),
 
     UNIQUE (emoji, user_id, comment_id) ON CONFLICT ROLLBACK
-);
-
--- Table: answers
-CREATE TABLE answers (
-    id        CHAR(8) UNIQUE NOT NULL,
-    time      VARCHAR(30) DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
-    user_id   CHAR(8) NOT NULL,
-    question_id CHAR(8) NOT NULL,
-    blob      TEXT,
-    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
-    FOREIGN KEY (question_id) REFERENCES questions(id) ON DELETE CASCADE,
-
-    UNIQUE (user_id, question_id) ON CONFLICT ROLLBACK
 );
 
 

--- a/server/src/database/test-data.sql
+++ b/server/src/database/test-data.sql
@@ -9,7 +9,7 @@ INSERT INTO containers (id, subdomain, url, user_id) VALUES ('APD-2222', 'dtwo',
 INSERT INTO containers (id, subdomain, url, user_id) VALUES ('APP-TEST', 'test', 'http://localhost:8080', 'da776df3');
 INSERT INTO containers (id, subdomain, url, user_id) VALUES ('APP-OTHR', 'other', 'http://localhost:8080', 'da776df3');
 
-INSERT INTO threads (id, container_id) VALUES ('THR-1234', 'APP-1111');
+INSERT INTO threads (id, container_id) VALUES ('THR-1234', 'APP-TEST');
 
 INSERT INTO comments (id, time, text, user_id, thread_id) VALUES ('1bd8052b', '2018-11-14 16:35:27', 'skrattia', 'da776df3', 'THR-1234');
 INSERT INTO comments (id, time, text, user_id, thread_id) VALUES ('cb38e8f6', '2018-11-14 17:10:42', 'tröttistä', 'da776df3', 'THR-1234');

--- a/server/src/routes/comments.js
+++ b/server/src/routes/comments.js
@@ -128,16 +128,28 @@ router.get('/:threadId', catchErrors(async (req, res) => {
 //   "delRows": 1
 // }
 router.delete('/', catchErrors(async (req, res) => {
-  const { commentId } = req.body
-  console.log('CommentId: ', req.body)
+  const { commentId, commentUser } = req.body
   const { users } = await reqUser(req)
+  const { owner } = await reqContainer(req)
   let delRows = {}
-  for (const userId in users) {
-    if (users.hasOwnProperty(userId)) {
-      try {
-        delRows = await deleteComment({ commentId, userId })
-        console.log(delRows)
-      } catch (err) { /* ignore */ }
+  if (users.hasOwnProperty(owner)) {
+    try {
+      delRows = await deleteComment({
+        commentId,
+        userId: commentUser,
+      })
+    } catch (err) { /* ignore */ }
+  } else {
+    for (const userId in users) {
+      if (users.hasOwnProperty(userId)) {
+        try {
+          delRows = await deleteComment({
+            commentId,
+            userId,
+          })
+        } catch (err) { /* ignore */
+        }
+      }
     }
   }
   res.json({ delRows })

--- a/server/src/routes/comments.js
+++ b/server/src/routes/comments.js
@@ -47,7 +47,7 @@ router.get('/', catchErrors(async (req, res) => {
         time: comment.comment_time,
         text: comment.comment_text,
         userId: comment.comment_user_id,
-        threadId: comment.thread_id,
+        threadId: comment.comment_thread_id,
         blob: JSON.parse(comment.comment_blob) || {},
         reactions: [],
       }
@@ -64,6 +64,7 @@ router.get('/', catchErrors(async (req, res) => {
       result.reactions.push(reaction)
     }
   }
+  console.log(groupedComments)
   res.send(groupedComments)
 }))
 

--- a/server/src/routes/comments.js
+++ b/server/src/routes/comments.js
@@ -64,7 +64,6 @@ router.get('/', catchErrors(async (req, res) => {
       result.reactions.push(reaction)
     }
   }
-  console.log(groupedComments)
   res.send(groupedComments)
 }))
 


### PR DESCRIPTION
Comments displayed in threads, with only the first comment visible on load.

Threads can be opened one at a time, with a submit-field at the bottom of every thread.

For all your own comments, a delete button is visible allowing you to delete the comment,

Comments from the original-poster have an "op" label after their name.

The tag element button has been moved to beside the comment button, under the submit-fields. Elements can be tagged on a thread basis, so you can tag a comment in one thread, open another one and tag another lement there.

TODO: 
 -~~Backend support for dev to delete any comment~~
 -~~Modal before deleting comment~~
 -Support for dev label
 -Support for mulitple labels
 -~~Overall styling improvements, transitions ...~~
 -~~Needs to be integrated with #35~~