### PR TITLE
Username cleanup

### DIFF
--- a/client/src/components/add-username-modal/add-username-modal.js
+++ b/client/src/components/add-username-modal/add-username-modal.js
@@ -36,19 +36,13 @@ class UsernameModal extends React.Component {
     event.preventDefault()
     event.nativeEvent.stopImmediatePropagation()
     const { users } = this.props
-    const [id] = Object.keys(users)
-    const secret = users[id]
     const name = this.state.value
-    await apiCall('PUT', '/users', {
-      name,
-      id,
-      secret,
-    })
+    await apiCall('PUT', '/users', { name })
     this.setState({
       value: '',
     })
     this.props.toggle()
-    this.props.dispatch(setPersistData({ users: { [id]: secret, name } }))
+    this.props.dispatch(setPersistData({ name }))
   }
 
   render() {

--- a/client/src/components/comment-panel/comment-panel.js
+++ b/client/src/components/comment-panel/comment-panel.js
@@ -26,6 +26,7 @@ const css = classNames.bind(commentPanelStyles)
 const mapStateToProps = state => ({
   comments: state.comments,
   users: (state.persist || {}).users || {},
+  name: (state.persist || {}).name,
   role: state.role,
 })
 
@@ -82,7 +83,7 @@ class CommentPanel extends React.Component {
     this.props.unsetTaggedElement()
     await this.fetchComments()
 
-    if (!this.props.users.name) {
+    if (!this.props.name) {
       await this.toggleUsernameModal()
     } else {
       await this.fetchComments()
@@ -197,7 +198,7 @@ class CommentPanel extends React.Component {
             toggleTagElementState={this.props.toggleTagElementState}
           />
           {
-            !this.props.users.name ? (
+            !this.props.name ? (
               <UsernameModal
                 isOpen={this.state.usernameModalIsOpen}
                 toggle={this.toggleUsernameModal}

--- a/client/src/components/comment-panel/comment-panel.js
+++ b/client/src/components/comment-panel/comment-panel.js
@@ -108,15 +108,12 @@ class CommentPanel extends React.Component {
   }
 
   toggleDeleteModal(comment) {
-    console.log('TOGGLING: ', comment)
     this.setState((prevState) => {
       if (R.isEmpty(prevState.commentToDelete)) {
-        console.log('yes')
         return { commentToDelete: comment }
       }
       return { commentToDelete: {} }
     })
-    console.log('STATE: ', this.state.commentToDelete)
   }
 
   async deleteComment() {

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -168,7 +168,7 @@ const initialize = () => {
 
     if (allDataLoaded) {
       if (!state.users || R.isEmpty(state.users)) {
-        const { id, secret } = await apiCall('POST', '/users')
+        const { id, secret } = await apiCall('POST', '/users', { name: state.name })
 
         console.log('Created new user from API', { [id]: secret })
 

--- a/client/src/site.js
+++ b/client/src/site.js
@@ -57,7 +57,7 @@ const initialize = () => {
 
     if (allDataLoaded) {
       if (!state.users || R.isEmpty(state.users)) {
-        const { id, secret } = await apiCall('POST', '/users')
+        const { id, secret } = await apiCall('POST', '/users', { name: state.name })
 
         console.log('Created new user from API', { [id]: secret })
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -196,7 +196,7 @@ and the body should contain the new name eg.
 }
 ```
 
-### [GET /api/users/role](../server/src/routes/users.js#L72)
+### [GET /api/users/role](../server/src/routes/users.js#L74)
 
 Retrieve the role of the current user in the container.
 Returns either `"dev"` or `"user"`

--- a/docs/api.md
+++ b/docs/api.md
@@ -165,7 +165,7 @@ Returns JSON indicating whether deletion was successful or not
 
 ## Users
 
-### [POST /api/users](../server/src/routes/users.js#L22)
+### [POST /api/users](../server/src/routes/users.js#L23)
 
 Add user to database.
 Returns JSON that contains generated id and secret of added user.
@@ -185,7 +185,7 @@ Example response
     "secret": "ea2ca2565f484906bfd5096126816a"
 }
 ```
-### [PUT /api/users](../server/src/routes/users.js#L47)
+### [PUT /api/users](../server/src/routes/users.js#L44)
 
 Change username of existing user.
 The request requires the id, the secret and the new username for the user,
@@ -193,28 +193,10 @@ eg.
 ```json
 {
    "name": "Testuser2",
-   "id": "d6ac55e9",
-   "secret": "ea2ca2565f484906bfd5096126816a"
 }
 ```
-Returns 'ok' if the change was successful.
 
-### [PUT /api/users](../server/src/routes/users.js#L81)
-
-Change username of existing user.
-The request requires the id, the secret and the new username for the user,
-eg.
-```json
-{
-   "name": "Testuser2",
-   "id": "d6ac55e9",
-   "secret": "ea2ca2565f484906bfd5096126816a"
-}
-```
-Returns 'ok' if the change was successful.
-
-
-### [GET /api/users/role](../server/src/routes/users.js#L62)
+### [GET /api/users/role](../server/src/routes/users.js#L72)
 
 Retrieve the role of the current user in the container.
 Returns either `"dev"` or `"user"`

--- a/docs/api.md
+++ b/docs/api.md
@@ -188,8 +188,8 @@ Example response
 ### [PUT /api/users](../server/src/routes/users.js#L44)
 
 Change username of existing user.
-The request requires the id, the secret and the new username for the user,
-eg.
+The user is specified using the Authorization header as with other endpoints
+and the body should contain the new name eg.
 ```json
 {
    "name": "Testuser2",

--- a/server/src/database/database-sqlite.js
+++ b/server/src/database/database-sqlite.js
@@ -136,7 +136,7 @@ class SQLiteDatabase {
 
   async del(...args) {
     return new Promise((resolve, reject) => {
-      this.db.run(...args, function (err) {
+      this.db.run(...args, function handleRes(err) {
         if (err) {
           verboseError(`DELERROR: ${err} on query ${args}`)
           reject(err)

--- a/server/src/routes/users.js
+++ b/server/src/routes/users.js
@@ -48,12 +48,14 @@ router.put('/', catchErrors(async (req, res) => {
 
   let anySuccess = false
   for (const id in users) {
-    const secret = users[id]
-    try {
-      await addUsername({ name, id, secret })
-      anySuccess = true
-    } catch (error) {
-      console.error(`Failed to change username for ${id}`, error)
+    if (users.hasOwnProperty(id)) {
+      const secret = users[id]
+      try {
+        await addUsername({ name, id, secret })
+        anySuccess = true
+      } catch (error) {
+        console.error(`Failed to change username for ${id}`, error)
+      }
     }
   }
 

--- a/server/src/routes/users.js
+++ b/server/src/routes/users.js
@@ -46,12 +46,20 @@ router.put('/', catchErrors(async (req, res) => {
   const name = req.body.name.trim()
   if (!name) throw new HttpError(400, 'Empty username')
 
+  let anySuccess = false
   for (const id in users) {
     const secret = users[id]
-    await attempt(async () => {
-      await addUsername({ name, id, secret })
-    })
+    try {
+      await attempt(async () => {
+        await addUsername({ name, id, secret })
+      })
+      anySuccess = true
+    } catch (error) {
+      console.error(`Failed to change username for ${id}`, error)
+    }
   }
+
+  if (!anySuccess) throw new HttpError(500, 'Failed to change username')
 
   res.json({ })
 }))

--- a/server/src/routes/users.js
+++ b/server/src/routes/users.js
@@ -37,8 +37,8 @@ router.post('/', catchErrors(async (req, res) => {
 
 // @api PUT /api/users
 // Change username of existing user.
-// The request requires the id, the secret and the new username for the user,
-// eg. @json {
+// The user is specified using the Authorization header as with other endpoints
+// and the body should contain the new name eg. @json {
 //    "name": "Testuser2",
 // }
 router.put('/', catchErrors(async (req, res) => {

--- a/server/src/routes/users.js
+++ b/server/src/routes/users.js
@@ -50,9 +50,7 @@ router.put('/', catchErrors(async (req, res) => {
   for (const id in users) {
     const secret = users[id]
     try {
-      await attempt(async () => {
-        await addUsername({ name, id, secret })
-      })
+      await addUsername({ name, id, secret })
       anySuccess = true
     } catch (error) {
       console.error(`Failed to change username for ${id}`, error)


### PR DESCRIPTION
Username used to be stored in `persist.users` which means that code used to treat it as an extra user hash pair. This PR moves it to `persist` root. Also instead of setting the name of a single user set it for all users determined by the `Authorization` header.

Also misc code cleanup like removing a duplicate function and debug logging.