### PR TITLE
Fix survey name modal logic

### DIFF
--- a/client/src/components/survey/answer.js
+++ b/client/src/components/survey/answer.js
@@ -12,6 +12,7 @@ const css = classNames.bind(styles)
 
 const mapStateToProps = state => ({
   users: (state.persist || {}).users || {},
+  name: (state.persist || {}).name,
 })
 
 class Answer extends React.Component {
@@ -69,7 +70,7 @@ class Answer extends React.Component {
         blob,
       })
     }
-    if (!this.props.users.name) {
+    if (!this.props.name) {
       this.toggleUsernameModal()
     }
   }

--- a/client/src/components/survey/answer.js
+++ b/client/src/components/survey/answer.js
@@ -152,7 +152,7 @@ class Answer extends React.Component {
             )
           }
           {
-            !this.props.users.name
+            !this.props.name
               ? (
                 <UsernameModal
                   isOpen={this.state.usernameModalIsOpen}
@@ -180,7 +180,7 @@ class Answer extends React.Component {
             ))
           }
           {
-            !this.props.users.name
+            !this.props.name
               ? (
                 <UsernameModal
                   isOpen={this.state.usernameModalIsOpen}


### PR DESCRIPTION
It used the wrong state path for the username and displayed the modal on every survey answer or edit.