### PR TITLE
Make doctype detection regex case-insensitive

### DIFF
--- a/proxy/server/server.go
+++ b/proxy/server/server.go
@@ -68,7 +68,7 @@ func StartServing(config *Config) error {
 // -- Implementation
 
 // `scriptInjectString` is injected before `injectPositionRegex`
-var doctypeRegex = regexp.MustCompile("<!DOCTYPE")
+var doctypeRegex = regexp.MustCompile("(?i)<!doctype")
 var injectPositionRegex = regexp.MustCompile("(?i)</body>")
 var doctypeInjectString string
 var doctypeInjectLength int


### PR DESCRIPTION
Turns out `<!doctype html>` is valid and even happens in real life