### PR TITLE
Re-fetch survey questions / answers

### DIFF
--- a/client/src/feedbacker-components/survey-edit/survey-edit-container.js
+++ b/client/src/feedbacker-components/survey-edit/survey-edit-container.js
@@ -145,10 +145,10 @@ export default class SurveyEditContainer extends React.Component {
     this.setState({ questions })
 
     const { edit, openId } = this.state
-    if (edit && edit.id && !questions.some(q => q.id == edit.id)) {
+    if (edit && edit.id && !questions.some(q => q.id === edit.id)) {
       this.setState({ edit: { } })
     }
-    if (openId && !questions.some(q => q.id == openId)) {
+    if (openId && !questions.some(q => q.id === openId)) {
       this.setState({ openId: null })
     }
   }

--- a/client/src/feedbacker-components/survey-edit/survey-edit-container.js
+++ b/client/src/feedbacker-components/survey-edit/survey-edit-container.js
@@ -139,9 +139,10 @@ export default class SurveyEditContainer extends React.Component {
   }
 
   async refetch() {
-    const questions = await apiCall('GET', '/questions')
+    const fetchedQuestions = await apiCall('GET', '/questions')
     const pending = this.state.questions.filter(q => q.id === PENDING_ID)
-    this.setState({ questions: [...questions, ...pending] })
+    const questions = [...fetchedQuestions, ...pending]
+    this.setState({ questions })
 
     const { edit, openId } = this.state
     if (edit && edit.id && !questions.some(q => q.id == edit.id)) {

--- a/client/src/feedbacker-components/survey-panel/survey-panel.js
+++ b/client/src/feedbacker-components/survey-panel/survey-panel.js
@@ -45,7 +45,7 @@ class SurveyPanel extends React.Component {
             </div>
             {role === 'dev' ? (
               <div className={css('panel-body', 'edit-container')}>
-                <SurveyEditContainer />
+                <SurveyEditContainer open={!hidden} />
               </div>
             ) : (
               <div className={css('panel-body')}>


### PR DESCRIPTION
Fetch questions every 10 seconds when the survey panel is open in edit mode.
This also means it fetches new/modified/deleted questions if there's two developer views open simultaneously.

Special cases tested:
- Create while
  - create: OK
  - edit: OK
  - sort: Doesn't let you sort beyond the new comment
  - open: OK
  - delete: OK
- Edit while
  - create: OK
  - edit other: OK
  - edit edited: Save overrides, Cancel takes edited
  - sort other: OK
  - sort edited: Edit becomes visible after the sort is done
  - open other: OK
  - open edited: OK
  - delete: OK
- Delete while
  - create: OK
  - edit other: OK
  - edit deleted: OK
  - sort other: OK
  - sort deleted: Visual glitch, deletes when released
  - open other: OK
  - open deleted: OK
  - delete: OK
- Sort while
  - create: OK
  - edit other: OK
  - edit sorted: OK
  - sort: Later sort overrides previous one
  - open: OK
  - delete: OK

## Review Checklist

- [x] All changes are described in the PR description
- [x] New feature and breaking changes have documentation
- [x] New endpoints have API tests
- [ ] New frontend features have Enzyme tests
- [x] No unnecessary or debugging code
- [x] Questionable code is clearly marked with comments

