### PR TITLE
Fix container errors

### DIFF
--- a/server/src/database/migrations/sqlite/001-setup.sql
+++ b/server/src/database/migrations/sqlite/001-setup.sql
@@ -27,7 +27,7 @@ CREATE TABLE threads (
   id            CHAR(8) UNIQUE NOT NULL,
   container_id  CHAR(8),
   blob          TEXT,
-  FOREIGN KEY (container_id) REFERENCES containers(id) ON DELETE SET NULL
+  FOREIGN KEY (container_id) REFERENCES containers(id) ON DELETE CASCADE
 );
 
 -- Table: comments

--- a/server/src/database/migrations/sqlite/001-setup.sql
+++ b/server/src/database/migrations/sqlite/001-setup.sql
@@ -25,9 +25,9 @@ CREATE TABLE containers (
 -- Table: threads
 CREATE TABLE threads (
   id            CHAR(8) UNIQUE NOT NULL,
-  container_id  CHAR(8) NOT NULL,
+  container_id  CHAR(8),
   blob          TEXT,
-  FOREIGN KEY (container_id) REFERENCES containers(id) ON DELETE CASCADE
+  FOREIGN KEY (container_id) REFERENCES containers(id) ON DELETE SET NULL
 );
 
 -- Table: comments

--- a/server/src/database/migrations/sqlite/001-setup.sql
+++ b/server/src/database/migrations/sqlite/001-setup.sql
@@ -27,7 +27,7 @@ CREATE TABLE threads (
   id            CHAR(8) UNIQUE NOT NULL,
   container_id  CHAR(8),
   blob          TEXT,
-  FOREIGN KEY (container_id) REFERENCES containers(id) ON DELETE NO ACTION
+  FOREIGN KEY (container_id) REFERENCES containers(id) ON DELETE SET NULL
 );
 
 -- Table: comments

--- a/server/src/database/migrations/sqlite/001-setup.sql
+++ b/server/src/database/migrations/sqlite/001-setup.sql
@@ -27,7 +27,7 @@ CREATE TABLE threads (
   id            CHAR(8) UNIQUE NOT NULL,
   container_id  CHAR(8),
   blob          TEXT,
-  FOREIGN KEY (container_id) REFERENCES containers(id) ON DELETE SET NULL
+  FOREIGN KEY (container_id) REFERENCES containers(id) ON DELETE NO ACTION
 );
 
 -- Table: comments


### PR DESCRIPTION
<!-- Describe your changes here -->

Previously we couldn't remove an external site because threads had container_id as foreign key and foreign key constraint failed.
‼️
REVIEWERS: Comment suggestions for a better solution.
‼️

## Review Checklist

- [ ] All changes are described in the PR description
- [ ] New feature and breaking changes have documentation
- [ ] No unnecessary or debugging code
- [ ] Questionable code is clearly marked with comments

