### PR TITLE
Remember comment/survey panel state in session storage

### DIFF
--- a/client/src/index.js
+++ b/client/src/index.js
@@ -22,6 +22,7 @@ import Onboarding from './feedbacker-components/onboarding/onboarding'
 
 // Internal js
 import { setupPersist } from './persist'
+import { getSession, updateSession } from './session'
 import { loadPersistData, setPersistData, loadComments, updateRole } from './actions'
 // Styles
 import './scss/atoms-organisms/_toast.scss'
@@ -108,14 +109,24 @@ class MainView extends React.Component {
     this.handleElementTagged = this.handleElementTagged.bind(this)
     this.unsetTaggedElement = this.unsetTaggedElement.bind(this)
 
+    const {
+      surveyPanelIsHidden = true,
+      commentPanelIsHidden = true,
+    } = getSession()
+
     this.state = {
-      surveyPanelIsHidden: true,
-      commentPanelIsHidden: true,
+      surveyPanelIsHidden,
+      commentPanelIsHidden,
       surveyButtonAnimation: false,
       commentButtonAnimation: false,
       taggingModeActive: false,
       taggedElementXPath: '',
     }
+  }
+
+  componentDidUpdate() {
+    const { surveyPanelIsHidden, commentPanelIsHidden } = this.state
+    updateSession({ surveyPanelIsHidden, commentPanelIsHidden })
   }
 
   handleSurveyPanelClick() {

--- a/client/src/session.js
+++ b/client/src/session.js
@@ -1,0 +1,23 @@
+
+const sessionKey = '!!feedbacker_session_data!!'
+let session = null
+
+export function getSession() {
+  if (session == null) {
+    try {
+      const json = sessionStorage.getItem(sessionKey) || '{}'
+      session = JSON.parse(json)
+    } catch (error) {
+      console.error('Failed to parse session storage', error)
+      session = { }
+    }
+  }
+  return session
+}
+
+export function updateSession(object) {
+  const prev = session || { }
+  session = { ...prev, ...object }
+  sessionStorage.setItem(sessionKey, JSON.stringify(session))
+}
+


### PR DESCRIPTION
Save comment and survey panel hidden state in session storage. Currently this is not done using `persist` since it's not that critical and does not need to be shared between instances.

## Review Checklist

- [x] All changes are described in the PR description
- [x] New feature and breaking changes have documentation
- [x] New endpoints have API tests
- [x] New frontend features have Enzyme tests
- [x] No unnecessary or debugging code
- [x] Questionable code is clearly marked with comments

