### PR TITLE
Rename Authorization to X-Feedback-Auth

### DIFF
--- a/client/src/api-call.js
+++ b/client/src/api-call.js
@@ -59,7 +59,7 @@ export default async function apiCall(method, endpoint, body = null, opts = { })
   const args = {
     headers: {
       'X-Feedback-Host': window.location.hostname,
-      'Authorization': `Feedbacker ${authToken}`,
+      'X-Feedback-Auth': authToken,
     },
     method,
   }

--- a/docs/api.md
+++ b/docs/api.md
@@ -17,7 +17,7 @@ Instance specific endpoints like comments expect the current instance to be pass
 
 ### Authentication
 
-Authentication is done using the standard `Authorization` header with a non-standard `Feedbacker` scheme. The content of the authorization header is a base-64 encoded **user object**. As the feedback tool may generate multiple user tokens for the same user merging them later users are represented as an object of the form:
+Authentication is done using a custom `X-Feedback-Auth` header. The content of the custom authorization header is a base-64 encoded **user object**. As the feedback tool may generate multiple user tokens for the same user merging them later users are represented as an object of the form:
 
 ```json
 {
@@ -233,7 +233,7 @@ Example response
 ### [PUT /api/users](../server/src/routes/users.js#L45)
 
 Change username of existing user.
-The user is specified using the Authorization header as with other endpoints
+The user is specified using the X-Feedback-Auth header as with other endpoints
 and the body should contain the new name eg.
 ```json
 {

--- a/misc/api-template.md
+++ b/misc/api-template.md
@@ -14,7 +14,7 @@ Instance specific endpoints like comments expect the current instance to be pass
 
 ### Authentication
 
-Authentication is done using the standard `Authorization` header with a non-standard `Feedbacker` scheme. The content of the authorization header is a base-64 encoded **user object**. As the feedback tool may generate multiple user tokens for the same user merging them later users are represented as an object of the form:
+Authentication is done using a custom `X-Feedback-Auth` header. The content of the custom authorization header is a base-64 encoded **user object**. As the feedback tool may generate multiple user tokens for the same user merging them later users are represented as an object of the form:
 
 ```json
 {

--- a/server/src/api-tests/api-request.js
+++ b/server/src/api-tests/api-request.js
@@ -55,7 +55,7 @@ export default function apiRequest(method, path, body, optsArg) {
     method,
     body,
     headers: {
-      Authorization: `Feedbacker ${authToken}`,
+      'X-Feedback-Auth': `Feedbacker ${authToken}`,
       'X-Feedback-Host': `${container}.localhost`,
     },
     ...(opts.request || {}),

--- a/server/src/api-tests/api-request.js
+++ b/server/src/api-tests/api-request.js
@@ -55,7 +55,7 @@ export default function apiRequest(method, path, body, optsArg) {
     method,
     body,
     headers: {
-      'X-Feedback-Auth': `Feedbacker ${authToken}`,
+      'X-Feedback-Auth': authToken,
       'X-Feedback-Host': `${container}.localhost`,
     },
     ...(opts.request || {}),

--- a/server/src/routes/helpers.js
+++ b/server/src/routes/helpers.js
@@ -68,10 +68,8 @@ export async function reqContainer(req) {
 }
 
 export async function reqUser(req) {
-  const auth = req.get('Authorization')
-  if (!auth) throw new HttpError(401, 'No Authorization header')
-  const [scheme, token] = auth.split(' ')
-  if (scheme !== 'Feedbacker') throw new HttpError(401, 'Unsupported Authorization scheme')
+  const token = req.get('X-Feedback-Auth')
+  if (!token) throw new HttpError(401, 'No X-Feedback-Auth header')
   const users = JSON.parse(Buffer.from(token, 'base64').toString())
   const verifiedUsers = { }
 

--- a/server/src/routes/users.js
+++ b/server/src/routes/users.js
@@ -38,7 +38,7 @@ router.post('/', catchErrors(async (req, res) => {
 
 // @api PUT /api/users
 // Change username of existing user.
-// The user is specified using the Authorization header as with other endpoints
+// The user is specified using the X-Feedback-Auth header as with other endpoints
 // and the body should contain the new name eg. @json {
 //    "name": "Testuser2",
 // }


### PR DESCRIPTION
Using basic auth for development purposes collides with our usage of `Authorization` header.
Change the feedback tool to use a custom `X-Feedback-Auth` header instead.

## Review Checklist

- [x] All changes are described in the PR description
- [x] New feature and breaking changes have documentation
- [x] New endpoints have API tests
- [x] New frontend features have Enzyme tests
- [x] No unnecessary or debugging code
- [x] Questionable code is clearly marked with comments

