### PR TITLE
Remove +2h from timestamps (production uses postgres) and fix typo

### DIFF
--- a/client/src/feedbacker-components/comment/comment.js
+++ b/client/src/feedbacker-components/comment/comment.js
@@ -71,8 +71,7 @@ const Comment = ({ id, comment, role, op, onClick, buttonText, canDelete, delete
           className={css('timestamp')}
           date={comment.time}
           format="D.MM.YYYY HH.mm"
-          add={{ hours: 2 }} // REMOVE WHEN SWITCHING TO POSTGRES IN PROD
-          data-tooltip={moment(comment.time).add(2, 'hours').fromNow()} // REMOVE .add() WHEN SWITCHING TO POSTGRES IN PROD
+          data-tooltip={moment(comment.time).fromNow()}
           data-tooltip-south
           data-tooltip-width="100px"
         />

--- a/server/src/database/migrations/postgres/003-unique-reactions.sql
+++ b/server/src/database/migrations/postgres/003-unique-reactions.sql
@@ -2,7 +2,7 @@
 BEGIN TRANSACTION;
 
 ALTER TABLE reactions
-  ADD CONSTRAINT unique_emoji_user_id_comment_id_comstraint UNIQUE(emoji, user_id, comment_id);
+  ADD CONSTRAINT unique_emoji_user_id_comment_id_constraint UNIQUE(emoji, user_id, comment_id);
 
 COMMIT TRANSACTION;
 


### PR DESCRIPTION
<!-- Describe your changes here -->

Removed .add(2, 'h') from comment timestamps
Fix the famous 'comstraint' typo 

## Review Checklist

- [x] All changes are described in the PR description
- [x] New feature and breaking changes have documentation
- [x] New endpoints have API tests
- [x] New frontend features have Enzyme tests
- [x] No unnecessary or debugging code
- [x] Questionable code is clearly marked with comments

