### PR TITLE
Follow external redirects

### DIFF
--- a/client/src/dev-components/container-card.js
+++ b/client/src/dev-components/container-card.js
@@ -17,8 +17,13 @@ class ContainerCard extends React.Component {
   constructor(props) {
     super(props)
     this.instance = this.props.instance
-    this.instance.url = `//${this.instance.subdomain}.${window.location.host}`
     this.instance.name = this.instance.subdomain
+
+    this.instanceUrl = `//${this.instance.subdomain}.${window.location.host}`
+    const { blob } = this.instance
+    if (blob.path) {
+      this.instanceUrl += blob.path
+    }
 
     this.state = {
       containerRunning: this.instance.running,
@@ -114,7 +119,7 @@ class ContainerCard extends React.Component {
             Open instance logs
           </Link>
           <a
-            href={this.instance.url}
+            href={this.instanceUrl}
             target="_blank"
             rel="noreferrer noopener"
             className={css('accent')}

--- a/client/src/dev-components/create.js
+++ b/client/src/dev-components/create.js
@@ -85,7 +85,7 @@ class Create extends React.Component {
       type: 'site',
     })
 
-    window.location.replace(`//${json.containerInfo.subdomain}.${window.location.host}`)
+    window.location.replace(`//${json.containerInfo.subdomain}.${window.location.host}${json.redirectPath}`)
   }
 
   containerForm() {

--- a/client/src/dev-components/create.js
+++ b/client/src/dev-components/create.js
@@ -80,7 +80,6 @@ class Create extends React.Component {
       console.error('Failed to create container', error)
       this.setState({ busy: false })
     }
-
   }
 
   async postSite(event) {

--- a/client/src/dev-components/create.js
+++ b/client/src/dev-components/create.js
@@ -26,6 +26,7 @@ class Create extends React.Component {
       instanceRunners: [],
       redirectContainer: false,
       containerForm: true,
+      busy: false,
     }
   }
 
@@ -59,18 +60,27 @@ class Create extends React.Component {
     const doc = shadowDocument()
     const inputValue = name => doc.getElementById(name).value
 
-    const json = await apiCall('POST', '/instances/new', {
-      url: inputValue('url'),
-      version: inputValue('version'),
-      type: inputValue('application'),
-      port: inputValue('port'),
-      name: inputValue('name').toLowerCase(),
-    })
+    this.setState({ busy: true })
 
-    this.setState({
-      containerName: json.containerInfo.name,
-      redirectContainer: true,
-    })
+    try {
+      const json = await apiCall('POST', '/instances/new', {
+        url: inputValue('url'),
+        version: inputValue('version'),
+        type: inputValue('application'),
+        port: inputValue('port'),
+        name: inputValue('name').toLowerCase(),
+      })
+
+      this.setState({
+        containerName: json.containerInfo.name,
+        redirectContainer: true,
+        busy: false,
+      })
+    } catch (error) {
+      console.error('Failed to create container', error)
+      this.setState({ busy: false })
+    }
+
   }
 
   async postSite(event) {
@@ -79,16 +89,25 @@ class Create extends React.Component {
     const doc = shadowDocument()
     const inputValue = name => doc.getElementById(name).value
 
-    const json = await apiCall('POST', '/instances/new', {
-      url: inputValue('url'),
-      name: inputValue('name').toLowerCase(),
-      type: 'site',
-    })
+    this.setState({ busy: true })
 
-    window.location.replace(`//${json.containerInfo.subdomain}.${window.location.host}${json.redirectPath}`)
+    try {
+      const json = await apiCall('POST', '/instances/new', {
+        url: inputValue('url'),
+        name: inputValue('name').toLowerCase(),
+        type: 'site',
+      })
+
+      this.setState({ busy: false })
+      window.location.replace(`//${json.containerInfo.subdomain}.${window.location.host}${json.redirectPath}`)
+    } catch (error) {
+      console.error('Failed to create container', error)
+      this.setState({ busy: false })
+    }
   }
 
   containerForm() {
+    const { busy } = this.state
     return (
       <form
         className={css('form-create')}
@@ -142,7 +161,7 @@ class Create extends React.Component {
             >Back to dashboard
             </button>
           </Link>
-          <button type="submit">
+          <button type="submit" disabled={busy}>
             Create
           </button>
         </div>
@@ -151,6 +170,7 @@ class Create extends React.Component {
   }
 
   siteForm() {
+    const { busy } = this.state
     // TODO: Add tooltip to warn about live url redirection
     return (
       <form
@@ -195,6 +215,7 @@ class Create extends React.Component {
             type="submit"
             data-tooltip="Build can take a while, check again later if site unavailable"
             data-tooltip-width="220px"
+            disabled={busy}
           >
             Create
           </button>
@@ -213,8 +234,10 @@ class Create extends React.Component {
       )
     }
 
+    const { busy } = this.state
+
     return (
-      <div className={css('center-center-block')}>
+      <div className={css('center-center-block', { busy })}>
         <div className={css('create-view')}>
           <h2>Create an instance</h2>
           <div className={css('selection-tabs')}>

--- a/client/src/scss/views/create.scss
+++ b/client/src/scss/views/create.scss
@@ -74,6 +74,10 @@
   }
 }
 
+.busy * {
+  cursor: wait;
+}
+
 .inline-button {
   display: flex;
   align-items: baseline;

--- a/docs/api.md
+++ b/docs/api.md
@@ -255,13 +255,13 @@ Example body
 
 ## Instances
 
-### [GET /api/instances](../server/src/routes/instances.js#L24)
+### [GET /api/instances](../server/src/routes/instances.js#L48)
 
 Retrieve all instances in the database.
 
 Returns 200 OK and a JSON array of all instances or 500 ISE if an error occurred.
 
-### [POST /api/instances/new](../server/src/routes/instances.js#L59)
+### [POST /api/instances/new](../server/src/routes/instances.js#L83)
 
 Create a new instance.
 
@@ -277,13 +277,13 @@ Example body
 
 Returns 200 OK if the operation completed successfully and 500 ISE if an error occurred.
 
-### [GET /api/instances/logs/:name](../server/src/routes/instances.js#L37)
+### [GET /api/instances/logs/:name](../server/src/routes/instances.js#L61)
 
 Retrieve logs of an instance.
 
 Returns 200 OK and a string with logs or 500 ISE if an error occurred.
 
-### [POST /api/instances/start](../server/src/routes/instances.js#L126)
+### [POST /api/instances/start](../server/src/routes/instances.js#L160)
 
 Start a stopped container.
 
@@ -296,7 +296,7 @@ Example body
 
 Returns 200 OK if the operation completed successfully and 500 ISE if an error occurred.
 
-### [POST /api/instances/stop](../server/src/routes/instances.js#L107)
+### [POST /api/instances/stop](../server/src/routes/instances.js#L141)
 
 Stop a running container.
 
@@ -309,7 +309,7 @@ Example body
 
 Returns 200 OK if the operation completed successfully and 500 ISE if an error occurred.
 
-### [POST /api/instances/delete](../server/src/routes/instances.js#L145)
+### [POST /api/instances/delete](../server/src/routes/instances.js#L179)
 
 Delete a container
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -2117,6 +2117,24 @@
         "write": "^0.2.1"
       }
     },
+    "follow-redirects": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
+      "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
+      "requires": {
+        "debug": "^3.2.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",

--- a/server/package.json
+++ b/server/package.json
@@ -42,6 +42,7 @@
     "cors": "^2.8.5",
     "dockerode": "^2.5.8",
     "express": "^4.16.4",
+    "follow-redirects": "^1.7.0",
     "morgan": "^1.9.1",
     "pg": "^7.7.1",
     "pg-promise": "^8.5.4",

--- a/server/src/database.js
+++ b/server/src/database.js
@@ -221,7 +221,7 @@ export async function resolveContainer(subdomain) {
 }
 
 export async function listContainersByUser(values = []) {
-  return db.query('SELECT id, subdomain, runner FROM containers WHERE user_id=?', values)
+  return db.query('SELECT id, subdomain, runner, blob FROM containers WHERE user_id=?', values)
 }
 
 export async function removeContainer(name) {

--- a/server/src/docker.js
+++ b/server/src/docker.js
@@ -67,6 +67,7 @@ export async function getRunningContainersByUser(userId) {
   const trackedContainers = await listContainersByUser(userId)
   return Promise.all(trackedContainers.map(async (container) => {
     const containerCopy = container
+    containerCopy.blob = JSON.parse(container.blob || '{ }')
     try {
       const dockerContainerInfo = await getContainerInfoFromDocker(container.id)
       containerCopy.running = dockerContainerInfo.State.Running

--- a/server/src/routes/instances.js
+++ b/server/src/routes/instances.js
@@ -1,5 +1,7 @@
 import express from 'express'
 import * as R from 'ramda'
+import { http, https } from 'follow-redirects'
+import { URL } from 'url'
 import {
   createNewContainer,
   startContainer,
@@ -16,6 +18,29 @@ import logger from '../logger'
 
 const router = express.Router()
 
+function followRedirects(targetUrl) {
+  return new Promise((resolve, reject) => {
+    const client = targetUrl.startsWith('https') ? https : http
+    const request = client.get(targetUrl, (response) => {
+      const redirectedUrl = response.responseUrl.toString().trim()
+      const url = new URL(response.responseUrl)
+      request.abort()
+      resolve({
+        protocol: url.protocol,
+        host: url.host,
+        path: `${url.pathname}${url.search || ''}${url.hash || ''}`,
+      })
+    })
+
+    request.setTimeout(20000, (timeout) => {
+      reject(new HttpError(400, `Could not resolve URL, timed out: ${targetUrl}`))
+    })
+
+    request.on('error', (error) => {
+      reject(new HttpError(400, `Could not resolve URL: ${targetUrl}`, error))
+    })
+  })
+}
 
 // @api GET /api/instances
 // Retrieve all instances in the database.
@@ -77,13 +102,19 @@ router.post('/new', catchErrors(async (req, res) => {
   }
 
   if (type === 'site') {
+    const finalUrl = await followRedirects(url)
+
+    const rootUrl = `${finalUrl.protocol}//${finalUrl.host}`
+    const redirectPath = finalUrl.path
+
     await attempt(async () => {
       const subdomain = `${name}-${uuid(5)}`
       const id = uuid(8)
       const containerInfo = await addSite({
-        id, subdomain, userId, type, url,
+        id, subdomain, userId, type, url: rootUrl,
+        blob: JSON.stringify({ path: redirectPath }),
       })
-      res.json({ containerInfo })
+      res.json({ containerInfo, redirectPath })
     })
   } else {
     await attempt(async () => {

--- a/server/src/routes/instances.js
+++ b/server/src/routes/instances.js
@@ -22,7 +22,6 @@ function followRedirects(targetUrl) {
   return new Promise((resolve, reject) => {
     const client = targetUrl.startsWith('https') ? https : http
     const request = client.get(targetUrl, (response) => {
-      const redirectedUrl = response.responseUrl.toString().trim()
       const url = new URL(response.responseUrl)
       request.abort()
       resolve({
@@ -32,7 +31,7 @@ function followRedirects(targetUrl) {
       })
     })
 
-    request.setTimeout(20000, (timeout) => {
+    request.setTimeout(20000, () => {
       reject(new HttpError(400, `Could not resolve URL, timed out: ${targetUrl}`))
     })
 
@@ -111,7 +110,11 @@ router.post('/new', catchErrors(async (req, res) => {
       const subdomain = `${name}-${uuid(5)}`
       const id = uuid(8)
       const containerInfo = await addSite({
-        id, subdomain, userId, type, url: rootUrl,
+        id,
+        subdomain,
+        userId,
+        type,
+        url: rootUrl,
         blob: JSON.stringify({ path: redirectPath }),
       })
       res.json({ containerInfo, redirectPath })


### PR DESCRIPTION
Resolve external redirects on sites when creating an external site instance.
This also has the added benefit of detecting bad or typoed links.

Since the server has to do a `GET` request I tried to take security into account: The server cancels the requests as soon as the target URL is resolved.

This PR also adds a busy state to instance / external site creation while waiting for the response.

Q: Why don't you use `HEAD` request in the redirection lookup?
A: Some development servers actually don't handle `HEAD` correctly so it's safer to do a `GET` request that browsers also do.

## Review Checklist

- [x] All changes are described in the PR description
- [x] New feature and breaking changes have documentation
- [x] New endpoints have API tests
- [x] New frontend features have Enzyme tests
- [x] No unnecessary or debugging code
- [x] Questionable code is clearly marked with comments

