### PR TITLE
Clean up external sites in dashboard

### DIFF
--- a/client/src/dev-components/container-card.js
+++ b/client/src/dev-components/container-card.js
@@ -73,6 +73,8 @@ class ContainerCard extends React.Component {
   render() {
     const { instance } = this.props
 
+    const typeText = instance.runner === 'site' ? 'External site' : 'Instance'
+
     return (
       <div key={instance.id} className={css('instance-card')}>
         <div className={css('header-container')}>
@@ -107,12 +109,14 @@ class ContainerCard extends React.Component {
               <InlineSVG src={CloseIcon} />
             </button>
           </div>
-          <h5>Instance: {instance.subdomain}</h5>
+          <h5>{typeText}: {instance.subdomain}</h5>
         </div>
         <div className={css('button-container')}>
-          <Link to={`/logs/${instance.subdomain}`}>
-            Open instance logs
-          </Link>
+          {instance.runner !== 'site' ? (
+            <Link to={`/logs/${instance.subdomain}`}>
+              Open instance logs
+            </Link>
+          ) : null}
           <a
             href={this.instance.url}
             target="_blank"


### PR DESCRIPTION
Don't include logs button for external sites as the view is always empty. Also change the text to say `External site:` instead of `Instance:` on sites.

## Review Checklist

- [x] All changes are described in the PR description
- [x] New feature and breaking changes have documentation
- [x] New endpoints have API tests
- [x] New frontend features have Enzyme tests
- [x] No unnecessary or debugging code
- [x] Questionable code is clearly marked with comments

