### PR TITLE
Comment panel fixes

### DIFF
--- a/client/src/feedbacker-components/onboarding/onboarding.scss
+++ b/client/src/feedbacker-components/onboarding/onboarding.scss
@@ -33,14 +33,18 @@
   flex: 0;
   padding: 0 $padding;
 
-  button {
-    @extend %icon-button;
-    margin: 0;
-  }
-
   .next-button {
     transform: rotateY(180deg);
     margin-left: auto;
+
+    &:hover {
+      transform: rotateY(180deg);
+    }
+  }
+
+  button {
+    @extend %icon-button;
+    margin: 0;
   }
 }
 

--- a/client/src/feedbacker-components/submit-field/submit-field.js
+++ b/client/src/feedbacker-components/submit-field/submit-field.js
@@ -90,13 +90,13 @@ class SubmitField extends React.Component {
           <div className={css('anonymous-check')}>
             <input
               type="checkbox"
-              id="hideName"
+              id={`hideName-${this.props.threadId}`}
               name="Anonymous"
               checked={hideName}
               onChange={() => {}}
               onClick={this.toggleHide}
             />
-            <label htmlFor="hideName" className={css('check-text')}>
+            <label htmlFor={`hideName-${this.props.threadId}`} className={css('check-text')}>
               Anonymous
             </label>
           </div>

--- a/server/src/database/migrations/sqlite/001-setup.sql
+++ b/server/src/database/migrations/sqlite/001-setup.sql
@@ -65,8 +65,8 @@ CREATE TABLE reactions (
     emoji      VARCHAR(32) NOT NULL,
     user_id    CHAR(8) NOT NULL,
     comment_id CHAR(8) NOT NULL,
-    FOREIGN KEY (user_id) REFERENCES users(id),
-    FOREIGN KEY (comment_id) REFERENCES comments(id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (comment_id) REFERENCES comments(id) ON DELETE CASCADE,
 
     UNIQUE (emoji, user_id, comment_id) ON CONFLICT ROLLBACK
 );


### PR DESCRIPTION
This pr fixes some bugs/glitches in the comment panel.

* The anon buttons now use id's based on thread id so that the labels correctly toggle their own checkbox. This fixes the bug where if one thread was open the bottom anon-button would toggle the thread anon-button.

* Added on delete cascade to reaction foreign keys in sqlite. This now allows comments with reactions to correctly be removed.

* Fixes icon-button transformation in onboarding modal that was broken because of hover state in icon-buttons.

## Review Checklist

- [x] All changes are described in the PR description
- [x] New feature and breaking changes have documentation
- [x] New endpoints have API tests
- [x] New frontend features have Enzyme tests
- [x] No unnecessary or debugging code
- [x] Questionable code is clearly marked with comments

