### PR TITLE
changed Explanations to have 'Add text explanation' as a placeholder

### DIFF
--- a/client/src/feedbacker-components/survey-edit/survey-edit-card.js
+++ b/client/src/feedbacker-components/survey-edit/survey-edit-card.js
@@ -185,7 +185,7 @@ class SurveyEditCard extends React.Component {
               <textarea
                 value={question.text}
                 onChange={this.handleTextEdit}
-                placeholder="Write a question..."
+                placeholder={question.type !== 'text' || question.type !== 'option' ? 'Add text explanation' : 'Write a question...'}
                 autoFocus
                 onKeyPress={this.handleKeyPress}
                 disabled={commit}
@@ -239,4 +239,3 @@ class SurveyEditCard extends React.Component {
 }
 
 export default SortableElement(SurveyEditCard)
-

--- a/client/src/feedbacker-components/survey-edit/survey-edit-card.js
+++ b/client/src/feedbacker-components/survey-edit/survey-edit-card.js
@@ -185,7 +185,7 @@ class SurveyEditCard extends React.Component {
               <textarea
                 value={question.text}
                 onChange={this.handleTextEdit}
-                placeholder={question.type !== 'text' || question.type !== 'option' ? 'Add text explanation' : 'Write a question...'}
+                placeholder={question.type !== 'text' && question.type !== 'option' ? 'Add text explanation' : 'Write a question...'}
                 autoFocus
                 onKeyPress={this.handleKeyPress}
                 disabled={commit}


### PR DESCRIPTION
changed Explanations in survey  to have 'Add text explanation' as a placeholder

## Review Checklist

- [x] All changes are described in the PR description
- [x] New feature and breaking changes have documentation
- [x] New endpoints have API tests
- [x] New frontend features have Enzyme tests
- [x] No unnecessary or debugging code
- [x] Questionable code is clearly marked with comments
- [x] Manually tested with latest Firefox, Safari and Chrome

