### PR TITLE
Fixes to comment sorting and container cards

### DIFF
--- a/client/src/dev-components/container-card/container-card.js
+++ b/client/src/dev-components/container-card/container-card.js
@@ -128,7 +128,7 @@ class ContainerCard extends React.Component {
           </p>
         ) : null}
         <p>
-          <span>Created on:  </span>
+          <span>Created on: </span>
           <Moment
             className={css('timestamp')}
             date={instance.time}
@@ -136,7 +136,7 @@ class ContainerCard extends React.Component {
             data-tooltip-south
             data-tooltip-width="100px"
           />
-          <span>,&nbsp;&nbsp;</span>{moment(instance.time).fromNow()}
+          <span>,&nbsp;</span>{moment(instance.time).fromNow()}
         </p>
         <div className={css('button-container')}>
           {this.props.slackAuth

--- a/client/src/dev-components/container-card/container-card.js
+++ b/client/src/dev-components/container-card/container-card.js
@@ -130,15 +130,15 @@ class ContainerCard extends React.Component {
           </p>
         ) : null}
         <p>
-          {'Created on:  '}
+          <span>Created on:  </span>
           <Moment
             className={css('timestamp')}
             date={instance.time}
             format="D.MM.YYYY HH.mm"
-            data-tooltip={moment(instance.time).fromNow()}
             data-tooltip-south
             data-tooltip-width="100px"
           />
+          <span>,&nbsp;&nbsp;</span>{moment(instance.time).fromNow()}
         </p>
         <div className={css('button-container')}>
           {this.props.slackAuth

--- a/client/src/dev-components/container-card/container-card.js
+++ b/client/src/dev-components/container-card/container-card.js
@@ -29,6 +29,7 @@ class ContainerCard extends React.Component {
     const { blob } = this.instance
     if (blob.path) {
       this.instance.url += blob.path
+      this.instance.origin += blob.path
     }
 
     this.state = {
@@ -123,9 +124,11 @@ class ContainerCard extends React.Component {
           </div>
           <h5>{typeText}: {instance.subdomain}</h5>
         </div>
-        <p>
-          Go to source {instance.runner === 'site' ? 'site' : 'repo'}: <a href={instance.origin}>{new URL(instance.origin).hostname.split('.').reverse()[1]}</a>
-        </p>
+        {this.instance.origin ? (
+          <p>
+            Go to source {instance.runner === 'site' ? 'site' : 'repo'}: <a href={this.instance.origin}>{new URL(this.instance.origin).hostname.split('.').reverse()[1]}</a>
+          </p>
+        ) : null}
         <p>
           {'Created on:  '}
           <Moment

--- a/client/src/dev-components/container-card/container-card.js
+++ b/client/src/dev-components/container-card/container-card.js
@@ -116,8 +116,6 @@ class ContainerCard extends React.Component {
               type="button"
               disabled={this.isOperationPending()}
               onClick={this.removeContainer}
-              data-tooltip="Remove"
-              data-tooltip-width="100px"
             >
               <InlineSVG src={CloseIcon} />
             </button>

--- a/client/src/dev-components/container-card/container-card.js
+++ b/client/src/dev-components/container-card/container-card.js
@@ -133,8 +133,6 @@ class ContainerCard extends React.Component {
             className={css('timestamp')}
             date={instance.time}
             format="D.MM.YYYY HH.mm"
-            data-tooltip-south
-            data-tooltip-width="100px"
           />
           <span>,&nbsp;</span>{moment(instance.time).fromNow()}
         </p>

--- a/client/src/dev-components/sign-in-slack/sign-in-slack.js
+++ b/client/src/dev-components/sign-in-slack/sign-in-slack.js
@@ -17,6 +17,7 @@ const SlackSignButton = () => (
     className={css('slack-sign-button')}
   >
     <img
+      src="/slack/sign_in_with_slack.png"
       alt="Sign in with Slack"
     />
   </button>

--- a/client/src/dev-components/sign-in-slack/sign-in-slack.scss
+++ b/client/src/dev-components/sign-in-slack/sign-in-slack.scss
@@ -13,6 +13,5 @@
   img {
     height: 31px;
     width: auto;
-    content: static-url('/slack/sign_in_with_slack.png');
   }
 }

--- a/client/src/feedbacker-components/thread/thread.js
+++ b/client/src/feedbacker-components/thread/thread.js
@@ -42,13 +42,13 @@ class Thread extends React.Component {
 
   expandedThread(op) {
     if (this.threadIsExpanded()) { return }
-    const threadComments = this.props.comments.slice(1)
     const sortByTime = R.sortBy(comment => comment.time)
-    const sortedComments = sortByTime(threadComments)
+    const sortedComments = sortByTime(this.props.comments)
+    const threadComments = sortedComments.slice(1)
     return (
       <>
         {
-          sortedComments.map(
+          threadComments.map(
             comment => (
               <Comment
                 key={comment.id}

--- a/client/src/scss/atoms/_anchor.scss
+++ b/client/src/scss/atoms/_anchor.scss
@@ -6,24 +6,23 @@ a {
   color: $palette-accent;
 
   &:not([tabindex="-1"]) {
+    &:after {
+      content: '';
+      position: absolute;
+      bottom: -1px;
+      left: 0;
+      width: 0;
+      height: 1px;
+      background-color: $palette-accent;
+      transition: $transition-default-all;
+      opacity: 0;
+    }
 
+    &:hover:after {
+      width: 100%;
+      opacity: 1;
+
+    }
   }
 
-  &:after {
-    content: '';
-    position: absolute;
-    bottom: -1px;
-    left: 0;
-    width: 0;
-    height: 1px;
-    background-color: $palette-accent;
-    transition: $transition-default-all;
-    opacity: 0;
-  }
-
-  &:hover:after {
-    width: 100%;
-    opacity: 1;
-
-  }
 }


### PR DESCRIPTION
Fixed bug with comment sorting in threads leading to the parent comment being displayed twice and some other comment not being displayed.

Also changed look of container cards so that the X hours ago now is after the timestamp, not in a tooltip.
Added so that if no origin for a container is found in the database, no link to source is displayed.

Added whole path to source for external sites, not only domain.

Slack button bug (invalid code) fixed.

## Review Checklist

- [x] All changes are described in the PR description
- [x] New feature and breaking changes have documentation
- [x] New endpoints have API tests
- [x] New frontend features have Enzyme tests
- [x] No unnecessary or debugging code
- [x] Questionable code is clearly marked with comments
- [x] Manually tested with latest Firefox, Safari and Chrome

