### PR TITLE
Fix node-runner failing on container restart

### DIFF
--- a/docker/node-runner/startup.bash
+++ b/docker/node-runner/startup.bash
@@ -3,9 +3,10 @@
 set -xe
 
 if [ ! -d "/app" ]; then
-  git clone $GIT_CLONE_URL /app
-  git -C /app reset --hard $GIT_VERSION_HASH
-  npm install --prefix /app
+  git clone $GIT_CLONE_URL /app 
+  cd /app
+  git reset --hard $GIT_VERSION_HASH
+  npm install
 fi
 
 cd /app

--- a/docker/node-runner/startup.bash
+++ b/docker/node-runner/startup.bash
@@ -2,15 +2,11 @@
 
 set -xe
 
-if [ -d "/app" ]; then
-  cd /app
-  npm run start
-  exit
+if [ ! -d "/app" ]; then
+  git clone $GIT_CLONE_URL /app
+  git -C /app reset --hard $GIT_VERSION_HASH
+  npm install --prefix /app
 fi
 
-git clone $GIT_CLONE_URL /app
 cd /app
-git reset --hard $GIT_VERSION_HASH
-npm install
-
 npm run start

--- a/docker/node-runner/startup.bash
+++ b/docker/node-runner/startup.bash
@@ -2,6 +2,12 @@
 
 set -xe
 
+if [ -d "/app" ]; then
+  cd /app
+  npm run start
+  exit
+fi
+
 git clone $GIT_CLONE_URL /app
 cd /app
 git reset --hard $GIT_VERSION_HASH


### PR DESCRIPTION
Changed behaviour of `node-runner`. The startup script doesn't try to clone again if the `/app` directory already exists.