### PR TITLE
Fix runner status being padded with spaces

### DIFF
--- a/server/src/database/migrations/postgres/014-change-runner-status-type.sql
+++ b/server/src/database/migrations/postgres/014-change-runner-status-type.sql
@@ -1,1 +1,2 @@
 ALTER TABLE instance_runners ALTER COLUMN status TYPE TEXT;
+UPDATE instance_runners SET status=TRIM(status);

--- a/server/src/database/migrations/postgres/014-change-runner-status-type.sql
+++ b/server/src/database/migrations/postgres/014-change-runner-status-type.sql
@@ -1,0 +1,1 @@
+ALTER TABLE instance_runners ALTER COLUMN status TYPE TEXT;

--- a/server/src/routes/instanceRunners.js
+++ b/server/src/routes/instanceRunners.js
@@ -29,12 +29,7 @@ router.get('/', catchErrors(async (req, res) => {
 
   // join the user's custom runners with the system-provided ones
   instanceRunners.push(...config.runners)
-
-  // HACK: Trim runner status as database has padded status fields
-  res.send(instanceRunners.map(runner => ({
-    ...runner,
-    status: runner.status ? runner.status.trim() : '',
-  })))
+  res.send(instanceRunners)
 }))
 
 // @api POST /api/instanceRunners/new

--- a/server/src/routes/instanceRunners.js
+++ b/server/src/routes/instanceRunners.js
@@ -31,10 +31,10 @@ router.get('/', catchErrors(async (req, res) => {
   instanceRunners.push(...config.runners)
 
   // HACK: Trim runner status as database has padded status fields
-  res.send(instanceRunners.map(runner => {
+  res.send(instanceRunners.map(runner => ({
     ...runner,
     status: runner.status.trim(),
-  }))
+  })))
 }))
 
 // @api POST /api/instanceRunners/new

--- a/server/src/routes/instanceRunners.js
+++ b/server/src/routes/instanceRunners.js
@@ -29,7 +29,12 @@ router.get('/', catchErrors(async (req, res) => {
 
   // join the user's custom runners with the system-provided ones
   instanceRunners.push(...config.runners)
-  res.send(instanceRunners)
+
+  // HACK: Trim runner status as database has padded status fields
+  res.send(instanceRunners.map(runner => {
+    ...runner,
+    status: runner.status.trim(),
+  }))
 }))
 
 // @api POST /api/instanceRunners/new

--- a/server/src/routes/instanceRunners.js
+++ b/server/src/routes/instanceRunners.js
@@ -33,7 +33,7 @@ router.get('/', catchErrors(async (req, res) => {
   // HACK: Trim runner status as database has padded status fields
   res.send(instanceRunners.map(runner => ({
     ...runner,
-    status: runner.status.trim(),
+    status: runner.status ? runner.status.trim() : '',
   })))
 }))
 


### PR DESCRIPTION
Postgres used a fixed size `CHAR` column for the runner type which caused it to be padded with spaces...

## Review Checklist

- [ ] All changes are described in the PR description
- [ ] New feature and breaking changes have documentation
- [ ] New endpoints have API tests
- [ ] New frontend features have Enzyme tests
- [ ] No unnecessary or debugging code
- [ ] Questionable code is clearly marked with comments
- [ ] Manually tested with latest Firefox & Chrome

