### PR TITLE
Fix onboarding flashing when creating a new instance

### DIFF
--- a/client/src/feedbacker-components/onboarding/onboarding.js
+++ b/client/src/feedbacker-components/onboarding/onboarding.js
@@ -20,8 +20,8 @@ const final = 7
 const mapStateToProps = (state) => {
   const persist = state.persist || {}
   return ({
-    onboarding: !R.isEmpty(persist.users) && !persist.introCompleted,
-    dev: !R.isEmpty(persist.users) && state.role === 'dev',
+    onboarding: persist.users && !R.isEmpty(persist.users) && !persist.introCompleted,
+    dev: persist.users && !R.isEmpty(persist.users) && state.role === 'dev',
     acceptCookies: persist.acceptCookies,
   })
 }


### PR DESCRIPTION
When creating a new instance the users map is `null` which causes the onboarding to show.

## Review Checklist

- [x] All changes are described in the PR description
- [x] New feature and breaking changes have documentation
- [x] New endpoints have API tests
- [x] New frontend features have Enzyme tests
- [x] No unnecessary or debugging code
- [x] Questionable code is clearly marked with comments
- [x] Manually tested with latest Firefox & Chrome

